### PR TITLE
feat: add wildcard service domain support (Vibe Kanban)

### DIFF
--- a/internal/config/derive_test.go
+++ b/internal/config/derive_test.go
@@ -27,6 +27,11 @@ func TestGetZoneForDomain(t *testing.T) {
 		{"app.sub.example.com", "example.com", false},
 		{"notfound.net", "", true},
 		{"exampleXcom", "", true},
+		// Wildcard domain tests
+		{"*.example.com", "example.com", false},
+		{"*.api.example.com", "example.com", false},
+		{"*.other.io", "other.io", false},
+		{"*.notfound.net", "", true},
 	}
 
 	for _, tt := range tests {
@@ -323,6 +328,32 @@ func TestValidateService(t *testing.T) {
 			name:    "invalid proxy backend",
 			svc:     Service{Name: "app", Domain: "app.example.com", Proxy: &ProxyConfig{Backend: "no-port"}},
 			wantErr: "proxy.backend",
+		},
+		// Wildcard domain validation tests
+		{
+			name:    "valid wildcard domain",
+			svc:     Service{Name: "wildcard", Domain: "*.api.example.com"},
+			wantErr: "",
+		},
+		{
+			name:    "wildcard at root level",
+			svc:     Service{Name: "wildcard", Domain: "*.example.com"},
+			wantErr: "",
+		},
+		{
+			name:    "invalid wildcard format - missing dot",
+			svc:     Service{Name: "bad", Domain: "*example.com"},
+			wantErr: "domain",
+		},
+		{
+			name:    "invalid wildcard - no domain after",
+			svc:     Service{Name: "bad", Domain: "*."},
+			wantErr: "domain",
+		},
+		{
+			name:    "invalid wildcard - single label",
+			svc:     Service{Name: "bad", Domain: "*.com"},
+			wantErr: "domain",
 		},
 	}
 

--- a/internal/server/templates_admin.go
+++ b/internal/server/templates_admin.go
@@ -470,6 +470,7 @@ const adminTemplate = `<!DOCTYPE html>
                         <h4 style="margin: 0 0 0.5rem 0; color: #e94560;">Step 1: Basic Info</h4>
                         <input type="text" name="name" placeholder="Service name (e.g., grafana)" required>
                         <input type="text" name="domain" placeholder="grafana.example.com" required>
+                        <p style="color: #888; font-size: 0.8em; margin: 0.25rem 0 0 0;">Supports wildcards (e.g., *.api.example.com) to route all subdomains to one backend.</p>
                     </div>
 
                     <div style="margin-bottom: 1rem; padding: 0.75rem; background: #1a1a2e; border-radius: 4px;">


### PR DESCRIPTION
## Summary

Adds support for wildcard service domains (e.g., `*.api.example.com`) that route all matching subdomains to a single backend service.

## Changes

### HAProxy Configuration (`internal/haproxy/haproxy.go`)
- Added `domainToACLPattern()` helper function that converts wildcard domains to HAProxy suffix patterns
- `*.api.example.com` becomes `.api.example.com` for `hdr_end(host)` matching
- Exact domains pass through unchanged

### Zone Matching (`internal/config/derive.go`)
- Updated `GetZoneForDomain()` to strip `*.` prefix when looking up zones
- Wildcard domains like `*.api.example.com` now correctly match zone `example.com`

### Service Validation (`internal/config/derive.go`)
- Added validation for wildcard domain format:
  - Must start with `*.` (not just `*`)
  - Must have a valid domain after the wildcard (e.g., `*.example.com` is valid, `*.com` is not)

### UI (`internal/server/templates_admin.go`)
- Added help text in the Add Service form: "Supports wildcards (e.g., *.api.example.com) to route all subdomains to one backend."

### Tests
- Added wildcard tests to `TestGetZoneForDomain`
- Added wildcard validation tests to `TestValidateService`
- Added `TestDomainToACLPattern` for the new helper function
- Added `TestGenerateConfig_WildcardBackend` for HAProxy config generation

## How It Works

1. **DNS**: dnsmasq natively supports wildcard entries - the domain passes through as-is (`address=/*.api.example.com/10.0.0.1`)
2. **HAProxy**: Wildcards are converted to suffix patterns for `hdr_end(host)` matching, so `*.api.example.com` matches any request ending in `.api.example.com`
3. **Route53**: External DNS also supports wildcard records natively

## Example

Creating a service with domain `*.api.example.com` will:
- Route `foo.api.example.com`, `bar.api.example.com`, etc. to the configured backend
- Work with internal DNS (dnsmasq) and external DNS (Route53)
- Generate proper HAProxy ACL rules for suffix matching

---

This PR was written using [Vibe Kanban](https://vibekanban.com)