### PR TITLE
feat(services): serve static folders as a service backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ On top of that, the file server is deliberately strict:
 - Directories are never listed — a directory serves its `index.html` or returns 404.
 - `static_root` cannot be the filesystem root or a system directory (`/etc`, `/root`, `/proc`, …) — checked even through symlinks.
 - `Content-Type` is set explicitly from the file extension (no content sniffing), and `X-Content-Type-Options: nosniff` is sent on every response.
-- Errors render a standard hz error page, or the site's own `404.html` if present.
+- Errors render a standard hz error page, or the site's own `404.html` / `5xx.html` if present. (A wholly missing/unreadable root can't read its own error page, so that case always shows the built-in page.)
 
 Point `static_root` at a directory containing only files you intend to publish.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ A service can serve a folder of files instead of proxying to a backend. Set `pro
 
 HAProxy can't serve a directory itself, so hz runs a small internal file server (loopback-only, port `static_serve_port`, default `8091`) and routes the service's domains to it by Host header. Static services inherit wildcard SSL, split-horizon DNS, and the `internal_only` restriction exactly like proxied ones.
 
-Because hz runs as root, the file server is deliberately strict:
+hz runs as root, but **the file server does not**: it runs as a separate child process dropped to the unprivileged `nobody` user, so it physically cannot read files `nobody` can't — even a bug in the handler can't leak root-only secrets. (If hz can't drop privileges, it refuses to serve static rather than serve as root.) The served directory must therefore be readable by `nobody`.
+
+On top of that, the file server is deliberately strict:
 
 - Bound to `127.0.0.1` only — never directly reachable off-box.
 - Every file open is pinned inside `static_root` via `os.Root`; `../` and symlinks **cannot** escape the directory.

--- a/README.md
+++ b/README.md
@@ -186,9 +186,18 @@ Because hz runs as root, the file server is deliberately strict:
 - Every file open is pinned inside `static_root` via `os.Root`; `../` and symlinks **cannot** escape the directory.
 - Dotfiles and dot-directories (`.git`, `.env`, `.ssh`) are never served.
 - Directories are never listed — a directory serves its `index.html` or returns 404.
-- `static_root` cannot be the filesystem root or a system directory (`/etc`, `/root`, `/proc`, …).
+- `static_root` cannot be the filesystem root or a system directory (`/etc`, `/root`, `/proc`, …) — checked even through symlinks.
+- `Content-Type` is set explicitly from the file extension (no content sniffing), and `X-Content-Type-Options: nosniff` is sent on every response.
+- Errors render a standard hz error page.
 
 Point `static_root` at a directory containing only files you intend to publish.
+
+For single-page apps, set `"spa": true` so a browser refresh on a client-side route (a path with no file extension) serves `index.html` instead of 404:
+
+```json
+{ "name": "app", "domains": ["app.example.com"],
+  "proxy": { "static_root": "/etc/homelab-horizon/app", "spa": true } }
+```
 
 This is how the project hosts its own landing page (`docs/`): a static service on the public domain, served by hz, with auto SSL.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ A service can serve a folder of files instead of proxying to a backend. Set `pro
 
 HAProxy can't serve a directory itself, so hz runs a small internal file server (loopback-only, port `static_serve_port`, default `8091`) and routes the service's domains to it by Host header. Static services inherit wildcard SSL, split-horizon DNS, and the `internal_only` restriction exactly like proxied ones.
 
+Because hz runs as root, the file server is deliberately strict:
+
+- Bound to `127.0.0.1` only — never directly reachable off-box.
+- Every file open is pinned inside `static_root` via `os.Root`; `../` and symlinks **cannot** escape the directory.
+- Dotfiles and dot-directories (`.git`, `.env`, `.ssh`) are never served.
+- Directories are never listed — a directory serves its `index.html` or returns 404.
+- `static_root` cannot be the filesystem root or a system directory (`/etc`, `/root`, `/proc`, …).
+
+Point `static_root` at a directory containing only files you intend to publish.
+
 This is how the project hosts its own landing page (`docs/`): a static service on the public domain, served by hz, with auto SSL.
 
 ## High Availability

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ On top of that, the file server is deliberately strict:
 - Directories are never listed — a directory serves its `index.html` or returns 404.
 - `static_root` cannot be the filesystem root or a system directory (`/etc`, `/root`, `/proc`, …) — checked even through symlinks.
 - `Content-Type` is set explicitly from the file extension (no content sniffing), and `X-Content-Type-Options: nosniff` is sent on every response.
-- Errors render a standard hz error page.
+- Errors render a standard hz error page, or the site's own `404.html` if present.
 
 Point `static_root` at a directory containing only files you intend to publish.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Homelab Horizon consolidates all of this into a single web UI:
 - **WireGuard VPN Management**: Create clients, generate QR codes, manage peers
 - **Split-Horizon DNS**: Internal DNS via dnsmasq, external DNS via Route53, Name.com, Cloudflare, and more
 - **Reverse Proxy**: HAProxy with automatic Let's Encrypt wildcard SSL certificates
+- **Static Sites**: Serve a folder of files as a service — hz hosts it directly, HAProxy routes to it with the same auto SSL/DNS
 - **Service Monitoring**: Health checks with ntfy push notifications
 - **Self-Service Onboarding**: Users redeem invite tokens to get VPN configs
 - **IP Banning**: Per-service IP bans with timeout support
@@ -163,6 +164,23 @@ Once your zone is set up, adding a service is straightforward:
 - **Proxy**: HAProxy backend (`host:port`) — can be a LAN service or an external host
 
 Services don't have to be on your local network. The proxy backend can point to any reachable host:port — a Raspberry Pi on your LAN, a VM in the cloud, or a container on the same machine.
+
+### Static Sites
+
+A service can serve a folder of files instead of proxying to a backend. Set `proxy.static_root` to an absolute directory (mutually exclusive with `proxy.backend`):
+
+```json
+{
+  "name": "docs",
+  "domains": ["docs.example.com"],
+  "external_dns": { "ttl": 300 },
+  "proxy": { "static_root": "/etc/homelab-horizon/site" }
+}
+```
+
+HAProxy can't serve a directory itself, so hz runs a small internal file server (loopback-only, port `static_serve_port`, default `8091`) and routes the service's domains to it by Host header. Static services inherit wildcard SSL, split-horizon DNS, and the `internal_only` restriction exactly like proxied ones.
+
+This is how the project hosts its own landing page (`docs/`): a static service on the public domain, served by hz, with auto SSL.
 
 ## High Availability
 

--- a/cmd/homelab-horizon/main.go
+++ b/cmd/homelab-horizon/main.go
@@ -26,6 +26,16 @@ var (
 const servicePath = "/etc/systemd/system/homelab-horizon.service"
 
 func main() {
+	// Unprivileged static-file-server child mode. hz re-execs itself with this
+	// env set (dropped to an unprivileged user) and feeds the host->site map
+	// over stdin. Handle it before flag parsing and the MCP stdin-pipe probe,
+	// which would otherwise mistake our control pipe for an MCP client.
+	if addr := os.Getenv(server.StaticServerEnvAddr); addr != "" {
+		hzlog.Setup()
+		server.RunStaticServerChild(addr)
+		return
+	}
+
 	configPath := flag.String("config", "", "Path to configuration file (optional)")
 	install := flag.Bool("install", false, "Install systemd service")
 	check := flag.Bool("check", false, "Check system configuration and offer to fix issues")

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -57,6 +57,7 @@ type DeployResp struct {
 type ProxyResp struct {
 	Backend            string             `json:"backend"`
 	StaticRoot         string             `json:"staticRoot,omitempty"` // absolute dir served as static files (mutually exclusive with backend)
+	SPA                bool               `json:"spa,omitempty"`        // static only: serve index.html for unknown non-asset paths
 	HealthCheck        *HealthCheckResp   `json:"healthCheck,omitempty"`
 	InternalOnly       bool               `json:"internalOnly"`
 	Deploy             *DeployResp        `json:"deploy,omitempty"`
@@ -433,6 +434,7 @@ type ServiceRequestExternalDNS struct {
 type ServiceRequestProxy struct {
 	Backend      string                     `json:"backend"`
 	StaticRoot   string                     `json:"staticRoot,omitempty"` // absolute dir served as static files (mutually exclusive with backend)
+	SPA          bool                       `json:"spa,omitempty"`        // static only: serve index.html for unknown non-asset paths
 	HealthCheck  *ServiceRequestHealthCheck `json:"healthCheck,omitempty"`
 	InternalOnly bool                       `json:"internalOnly"`
 	Deploy       *ServiceRequestDeploy      `json:"deploy,omitempty"`

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -56,6 +56,7 @@ type DeployResp struct {
 
 type ProxyResp struct {
 	Backend            string             `json:"backend"`
+	StaticRoot         string             `json:"staticRoot,omitempty"` // absolute dir served as static files (mutually exclusive with backend)
 	HealthCheck        *HealthCheckResp   `json:"healthCheck,omitempty"`
 	InternalOnly       bool               `json:"internalOnly"`
 	Deploy             *DeployResp        `json:"deploy,omitempty"`
@@ -431,6 +432,7 @@ type ServiceRequestExternalDNS struct {
 
 type ServiceRequestProxy struct {
 	Backend      string                     `json:"backend"`
+	StaticRoot   string                     `json:"staticRoot,omitempty"` // absolute dir served as static files (mutually exclusive with backend)
 	HealthCheck  *ServiceRequestHealthCheck `json:"healthCheck,omitempty"`
 	InternalOnly bool                       `json:"internalOnly"`
 	Deploy       *ServiceRequestDeploy      `json:"deploy,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -487,6 +487,7 @@ func (e *ExternalDNS) GetIPs() []string {
 type ProxyConfig struct {
 	Backend         string         `json:"backend"`                    // host:port for HAProxy to forward to (mutually exclusive with StaticRoot)
 	StaticRoot      string         `json:"static_root,omitempty"`      // absolute path to a directory served as static files instead of proxying
+	SPA             bool           `json:"spa,omitempty"`              // static only: serve index.html for unknown non-asset paths (client-side routing)
 	HealthCheck     *HealthCheck   `json:"health_check,omitempty"`     // Optional health check
 	InternalOnly    bool           `json:"internal_only,omitempty"`    // Restrict to local network access only
 	Deploy          *DeployConfig  `json:"deploy,omitempty"`           // Blue-green deploy with current/next slots

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,6 +193,11 @@ type Config struct {
 	HAProxyHTTPPort   int    `json:"haproxy_http_port"`
 	HAProxyHTTPSPort  int    `json:"haproxy_https_port"`
 
+	// StaticServePort is the loopback port hz binds to serve static-folder
+	// services (ProxyConfig.StaticRoot). HAProxy routes those services here.
+	// Bound to 127.0.0.1 only — never publicly reachable. Defaults to 8091.
+	StaticServePort int `json:"static_serve_port,omitempty"`
+
 	// SSL/Let's Encrypt configuration
 	SSLEnabled        bool   `json:"ssl_enabled"`
 	SSLCertDir        string `json:"ssl_cert_dir"`
@@ -469,14 +474,35 @@ func (e *ExternalDNS) GetIPs() []string {
 	return nil
 }
 
-// ProxyConfig configures HAProxy reverse proxying for this service
+// ProxyConfig configures HAProxy reverse proxying for this service.
+//
+// A service routes to one of two backend sources, mutually exclusive:
+//   - Backend: an upstream host:port that HAProxy forwards to (reverse proxy).
+//   - StaticRoot: a local directory whose files hz serves itself. HAProxy
+//     routes the service's domains to hz's internal static listener
+//     (see Config.StaticServeAddr); the document root is chosen by Host.
+//
+// Static services still inherit wildcard SSL, split-horizon DNS, health
+// checks, timeouts, and internal-only restriction exactly like proxied ones.
 type ProxyConfig struct {
-	Backend         string         `json:"backend"`                    // host:port for HAProxy to forward to
+	Backend         string         `json:"backend"`                    // host:port for HAProxy to forward to (mutually exclusive with StaticRoot)
+	StaticRoot      string         `json:"static_root,omitempty"`      // absolute path to a directory served as static files instead of proxying
 	HealthCheck     *HealthCheck   `json:"health_check,omitempty"`     // Optional health check
 	InternalOnly    bool           `json:"internal_only,omitempty"`    // Restrict to local network access only
 	Deploy          *DeployConfig  `json:"deploy,omitempty"`           // Blue-green deploy with current/next slots
 	MaintenancePage string         `json:"maintenance_page,omitempty"` // HTML body served as 503 during maintenance
 	Timeouts        *ProxyTimeouts `json:"timeouts,omitempty"`         // Optional per-backend HAProxy timeout overrides
+}
+
+// StaticServeAddr returns the loopback address hz binds to serve static-folder
+// services, and that HAProxy backends for those services point at. Defaults to
+// 127.0.0.1:8091 when StaticServePort is unset.
+func (c *Config) StaticServeAddr() string {
+	port := c.StaticServePort
+	if port == 0 {
+		port = 8091
+	}
+	return fmt.Sprintf("127.0.0.1:%d", port)
 }
 
 // ProxyTimeouts holds optional per-backend HAProxy timeout overrides, in
@@ -582,6 +608,7 @@ func Default() *Config {
 		HAProxyConfigPath: "/etc/haproxy/haproxy.cfg",
 		HAProxyHTTPPort:   80,
 		HAProxyHTTPSPort:  443,
+		StaticServePort:   8091,
 
 		// SSL/Let's Encrypt configuration
 		SSLEnabled:        false,

--- a/internal/config/derive.go
+++ b/internal/config/derive.go
@@ -592,6 +592,14 @@ func (c *Config) ValidateService(svc *Service) error {
 			return &ValidationError{Field: "domain", Message: "domain must not be empty"}
 		}
 
+		// Reject anything that isn't a plain hostname. Domains are written
+		// verbatim into haproxy.cfg ACLs (hdr_end(host) -i <domain>); a stray
+		// newline or metacharacter that still suffix-matched a zone would let a
+		// crafted domain inject HAProxy directives.
+		if !isValidDomainName(domain) {
+			return &ValidationError{Field: "domain", Message: "domain contains invalid characters"}
+		}
+
 		// Validate wildcard domain format if present
 		if strings.HasPrefix(domain, "*") {
 			if !strings.HasPrefix(domain, "*.") {
@@ -649,7 +657,32 @@ func (c *Config) ValidateService(svc *Service) error {
 		}
 	}
 
+	// SPA fallback only applies to static-folder services.
+	if svc.Proxy != nil && svc.Proxy.SPA && svc.Proxy.StaticRoot == "" {
+		return &ValidationError{Field: "proxy.spa", Message: "spa requires static_root"}
+	}
+
 	return nil
+}
+
+// isValidDomainName reports whether d is a plain DNS hostname (optionally a
+// leading "*." wildcard) made only of letters, digits, dots and hyphens. It
+// deliberately rejects control characters, spaces, and HAProxy metacharacters
+// so a domain cannot inject directives into the generated haproxy.cfg.
+func isValidDomainName(d string) bool {
+	d = strings.TrimPrefix(d, "*.")
+	if d == "" || len(d) > 253 {
+		return false
+	}
+	for _, r := range d {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateZone validates a zone configuration
@@ -676,11 +709,21 @@ func (e *ValidationError) Error() string {
 	return e.Field + ": " + e.Message
 }
 
-// isSensitiveRoot reports whether p is the filesystem root or a system
-// directory that should never be exposed as a static site. Since hz runs as
-// root, serving one of these would publish credentials, keys, or kernel state.
+// isSensitiveRoot reports whether p is, or resolves to, the filesystem root or
+// a system directory that should never be exposed as a static site. The
+// literal path and its symlink-resolved target are both checked, so a
+// static_root that is a symlink to /etc can't slip past the guard.
 func isSensitiveRoot(p string) bool {
-	clean := filepath.Clean(p)
+	if isSensitivePath(filepath.Clean(p)) {
+		return true
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return isSensitivePath(resolved)
+	}
+	return false
+}
+
+func isSensitivePath(clean string) bool {
 	if clean == "/" {
 		return true
 	}

--- a/internal/config/derive.go
+++ b/internal/config/derive.go
@@ -158,14 +158,26 @@ func (c *Config) haproxyErrorsDir() string {
 func (c *Config) DeriveHAProxyBackends() []haproxy.Backend {
 	var backends []haproxy.Backend
 	for _, svc := range c.Services {
-		if svc.Proxy == nil || svc.Proxy.Backend == "" {
+		if svc.Proxy == nil {
+			continue
+		}
+
+		// A service routes either to an upstream host:port (Backend) or, for a
+		// static-folder service, to hz's own loopback static listener. Validation
+		// guarantees these are mutually exclusive.
+		static := svc.Proxy.StaticRoot != ""
+		server := svc.Proxy.Backend
+		if static {
+			server = c.StaticServeAddr()
+		}
+		if server == "" {
 			continue
 		}
 
 		b := haproxy.Backend{
 			Name:          svc.Name,
 			DomainMatches: svc.Domains,
-			Server:        svc.Proxy.Backend,
+			Server:        server,
 			InternalOnly:  svc.Proxy.InternalOnly,
 		}
 		if svc.Proxy.HealthCheck != nil && svc.Proxy.HealthCheck.Path != "" {
@@ -173,8 +185,9 @@ func (c *Config) DeriveHAProxyBackends() []haproxy.Backend {
 			b.CheckPath = svc.Proxy.HealthCheck.Path
 		}
 
-		// Blue-green deploy: override server with current/next slots
-		if svc.Proxy.Deploy != nil {
+		// Blue-green deploy: override server with current/next slots.
+		// Not applicable to static services (validation rejects the combo).
+		if !static && svc.Proxy.Deploy != nil {
 			b.Deploy = true
 			b.HTTPCheck = true
 			b.DeployBalance = svc.Proxy.Deploy.Balance
@@ -614,6 +627,19 @@ func (c *Config) ValidateService(svc *Service) error {
 		_, _, err := net.SplitHostPort(svc.Proxy.Backend)
 		if err != nil {
 			return &ValidationError{Field: "proxy.backend", Message: "invalid address format (expected host:port)"}
+		}
+	}
+
+	// Validate static-folder backend: mutually exclusive with proxying, absolute path.
+	if svc.Proxy != nil && svc.Proxy.StaticRoot != "" {
+		if svc.Proxy.Backend != "" {
+			return &ValidationError{Field: "proxy.static_root", Message: "static_root and backend are mutually exclusive"}
+		}
+		if svc.Proxy.Deploy != nil {
+			return &ValidationError{Field: "proxy.static_root", Message: "static_root cannot be combined with blue-green deploy"}
+		}
+		if !filepath.IsAbs(svc.Proxy.StaticRoot) {
+			return &ValidationError{Field: "proxy.static_root", Message: "must be an absolute path"}
 		}
 	}
 

--- a/internal/config/derive.go
+++ b/internal/config/derive.go
@@ -641,6 +641,12 @@ func (c *Config) ValidateService(svc *Service) error {
 		if !filepath.IsAbs(svc.Proxy.StaticRoot) {
 			return &ValidationError{Field: "proxy.static_root", Message: "must be an absolute path"}
 		}
+		// Guardrail against the catastrophic copy-paste (serving / or /etc as
+		// root). This is a footgun stop, not the isolation boundary — the
+		// runtime os.Root confinement in the static server is.
+		if isSensitiveRoot(svc.Proxy.StaticRoot) {
+			return &ValidationError{Field: "proxy.static_root", Message: "refusing to serve a system directory"}
+		}
 	}
 
 	return nil
@@ -668,6 +674,22 @@ type ValidationError struct {
 
 func (e *ValidationError) Error() string {
 	return e.Field + ": " + e.Message
+}
+
+// isSensitiveRoot reports whether p is the filesystem root or a system
+// directory that should never be exposed as a static site. Since hz runs as
+// root, serving one of these would publish credentials, keys, or kernel state.
+func isSensitiveRoot(p string) bool {
+	clean := filepath.Clean(p)
+	if clean == "/" {
+		return true
+	}
+	for _, s := range []string{"/etc", "/root", "/boot", "/proc", "/sys", "/dev", "/run"} {
+		if clean == s || strings.HasPrefix(clean, s+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // extractIP extracts the IP address from an address string (removes port if present)

--- a/internal/config/derive_test.go
+++ b/internal/config/derive_test.go
@@ -614,6 +614,16 @@ func TestValidateService(t *testing.T) {
 			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/var/www/docs", Deploy: &DeployConfig{NextBackend: "192.168.1.1:8081"}}},
 			wantErr: "proxy.static_root",
 		},
+		{
+			name:    "static root filesystem root rejected",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/"}},
+			wantErr: "proxy.static_root",
+		},
+		{
+			name:    "static root /etc rejected",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/etc/ssl"}},
+			wantErr: "proxy.static_root",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/derive_test.go
+++ b/internal/config/derive_test.go
@@ -336,6 +336,37 @@ func TestDeriveHAProxyBackends(t *testing.T) {
 	}
 }
 
+func TestDeriveHAProxyBackends_Static(t *testing.T) {
+	cfg := &Config{
+		Services: []Service{
+			{
+				Name:    "docs",
+				Domains: []string{"docs.example.com"},
+				Proxy:   &ProxyConfig{StaticRoot: "/var/www/docs", InternalOnly: true},
+			},
+		},
+	}
+
+	backends := cfg.DeriveHAProxyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("Expected 1 backend, got %d", len(backends))
+	}
+	// Static services route to hz's own loopback static listener, not an upstream.
+	if backends[0].Server != cfg.StaticServeAddr() {
+		t.Errorf("Expected static backend server %s, got %s", cfg.StaticServeAddr(), backends[0].Server)
+	}
+	if !backends[0].InternalOnly {
+		t.Error("Expected static backend to inherit InternalOnly")
+	}
+
+	// A custom StaticServePort changes the derived backend address.
+	cfg.StaticServePort = 9099
+	backends = cfg.DeriveHAProxyBackends()
+	if backends[0].Server != "127.0.0.1:9099" {
+		t.Errorf("Expected static backend server 127.0.0.1:9099, got %s", backends[0].Server)
+	}
+}
+
 func TestDeriveHAProxyBackends_MultiDomain(t *testing.T) {
 	cfg := &Config{
 		Services: []Service{
@@ -561,6 +592,27 @@ func TestValidateService(t *testing.T) {
 			name:    "invalid wildcard - single label",
 			svc:     Service{Name: "bad", Domains: []string{"*.com"}},
 			wantErr: "domain",
+		},
+		// Static-folder backend validation
+		{
+			name:    "valid static root",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/var/www/docs"}},
+			wantErr: "",
+		},
+		{
+			name:    "static root relative path",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "var/www/docs"}},
+			wantErr: "proxy.static_root",
+		},
+		{
+			name:    "static root and backend mutually exclusive",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/var/www/docs", Backend: "192.168.1.1:8080"}},
+			wantErr: "proxy.static_root",
+		},
+		{
+			name:    "static root with deploy rejected",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/var/www/docs", Deploy: &DeployConfig{NextBackend: "192.168.1.1:8081"}}},
+			wantErr: "proxy.static_root",
 		},
 	}
 

--- a/internal/config/derive_test.go
+++ b/internal/config/derive_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -624,6 +626,21 @@ func TestValidateService(t *testing.T) {
 			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/etc/ssl"}},
 			wantErr: "proxy.static_root",
 		},
+		{
+			name:    "spa with static root ok",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{StaticRoot: "/var/www/docs", SPA: true}},
+			wantErr: "",
+		},
+		{
+			name:    "spa without static root rejected",
+			svc:     Service{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &ProxyConfig{Backend: "192.168.1.1:80", SPA: true}},
+			wantErr: "proxy.spa",
+		},
+		{
+			name:    "domain with control character rejected",
+			svc:     Service{Name: "x", Domains: []string{"evil\n  acl.example.com"}},
+			wantErr: "domain",
+		},
 	}
 
 	for _, tt := range tests {
@@ -644,6 +661,24 @@ func TestValidateService(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// A static_root that is a symlink to a system directory must be rejected — the
+// literal path looks innocent, so the guard has to resolve symlinks.
+func TestValidateService_RejectsSymlinkedSensitiveRoot(t *testing.T) {
+	cfg := &Config{Zones: []Zone{{Name: "example.com", ZoneID: "Z1"}}}
+
+	link := filepath.Join(t.TempDir(), "innocent")
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	svc := Service{Name: "x", Domains: []string{"x.example.com"}, Proxy: &ProxyConfig{StaticRoot: link}}
+	err := cfg.ValidateService(&svc)
+	ve, ok := err.(*ValidationError)
+	if !ok || ve.Field != "proxy.static_root" {
+		t.Fatalf("expected proxy.static_root error, got %v", err)
 	}
 }
 

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -125,6 +125,7 @@ func (s *Server) handleAPIServices(w http.ResponseWriter, r *http.Request) {
 			pr := &apitypes.ProxyResp{
 				Backend:      svc.Proxy.Backend,
 				StaticRoot:   svc.Proxy.StaticRoot,
+				SPA:          svc.Proxy.SPA,
 				InternalOnly: svc.Proxy.InternalOnly,
 			}
 			if svc.Proxy.HealthCheck != nil {

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -121,9 +121,10 @@ func (s *Server) handleAPIServices(w http.ResponseWriter, r *http.Request) {
 				TTL:           svc.ExternalDNS.TTL,
 			}
 		}
-		if svc.Proxy != nil && svc.Proxy.Backend != "" {
+		if svc.Proxy != nil && (svc.Proxy.Backend != "" || svc.Proxy.StaticRoot != "") {
 			pr := &apitypes.ProxyResp{
 				Backend:      svc.Proxy.Backend,
+				StaticRoot:   svc.Proxy.StaticRoot,
 				InternalOnly: svc.Proxy.InternalOnly,
 			}
 			if svc.Proxy.HealthCheck != nil {

--- a/internal/server/handlers_api_mutations.go
+++ b/internal/server/handlers_api_mutations.go
@@ -66,6 +66,7 @@ func serviceRequestToService(req *apitypes.ServiceRequest) config.Service {
 		svc.Proxy = &config.ProxyConfig{
 			Backend:      req.Proxy.Backend,
 			StaticRoot:   req.Proxy.StaticRoot,
+			SPA:          req.Proxy.SPA,
 			InternalOnly: req.Proxy.InternalOnly,
 		}
 		if req.Proxy.HealthCheck != nil && req.Proxy.HealthCheck.Path != "" {
@@ -211,6 +212,7 @@ func (s *Server) handleAPIEditService(w http.ResponseWriter, r *http.Request) {
 				cfg.Services[i].Proxy = &config.ProxyConfig{
 					Backend:         req.Proxy.Backend,
 					StaticRoot:      req.Proxy.StaticRoot,
+					SPA:             req.Proxy.SPA,
 					InternalOnly:    req.Proxy.InternalOnly,
 					MaintenancePage: existingMaintenancePage,
 					Timeouts:        requestProxyTimeouts(req.Proxy.Timeouts),

--- a/internal/server/handlers_api_mutations.go
+++ b/internal/server/handlers_api_mutations.go
@@ -62,9 +62,10 @@ func serviceRequestToService(req *apitypes.ServiceRequest) config.Service {
 		}
 		svc.ExternalDNS = extDNS
 	}
-	if req.Proxy != nil && req.Proxy.Backend != "" {
+	if req.Proxy != nil && (req.Proxy.Backend != "" || req.Proxy.StaticRoot != "") {
 		svc.Proxy = &config.ProxyConfig{
 			Backend:      req.Proxy.Backend,
+			StaticRoot:   req.Proxy.StaticRoot,
 			InternalOnly: req.Proxy.InternalOnly,
 		}
 		if req.Proxy.HealthCheck != nil && req.Proxy.HealthCheck.Path != "" {
@@ -198,7 +199,7 @@ func (s *Server) handleAPIEditService(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Proxy
-			if req.Proxy != nil && req.Proxy.Backend != "" {
+			if req.Proxy != nil && (req.Proxy.Backend != "" || req.Proxy.StaticRoot != "") {
 				// Preserve existing deploy config (token/activeSlot) and the
 				// maintenance page, which the editor doesn't round-trip.
 				var existingDeploy *config.DeployConfig
@@ -209,6 +210,7 @@ func (s *Server) handleAPIEditService(w http.ResponseWriter, r *http.Request) {
 				}
 				cfg.Services[i].Proxy = &config.ProxyConfig{
 					Backend:         req.Proxy.Backend,
+					StaticRoot:      req.Proxy.StaticRoot,
 					InternalOnly:    req.Proxy.InternalOnly,
 					MaintenancePage: existingMaintenancePage,
 					Timeouts:        requestProxyTimeouts(req.Proxy.Timeouts),

--- a/internal/server/handlers_haproxy.go
+++ b/internal/server/handlers_haproxy.go
@@ -17,6 +17,12 @@ func (s *Server) syncHAProxyBackends() {
 	if err := s.cfg().WriteMaintenancePageFiles(); err != nil {
 		slog.Warn("WriteMaintenancePageFiles", "err", err)
 	}
+	// Refresh the host->root map for static-folder services so the internal
+	// file server reflects the current config alongside the HAProxy backends
+	// that route to it.
+	if s.static != nil {
+		s.static.Rebuild(s.cfg())
+	}
 	// Derive HAProxy backends from services
 	s.haproxy.SetBackends(s.cfg().DeriveHAProxyBackends())
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -90,6 +90,9 @@ func (m *MCPServer) registerTools() {
 			mcp.WithString("proxy_backend",
 				mcp.Description("HAProxy backend address (host:port)"),
 			),
+			mcp.WithString("proxy_static_root",
+				mcp.Description("Absolute directory served as static files instead of proxying to a backend (mutually exclusive with proxy_backend)"),
+			),
 			mcp.WithString("health_check_path",
 				mcp.Description("HTTP health check path for HAProxy (e.g. /health)"),
 			),
@@ -345,9 +348,11 @@ func (m *MCPServer) buildService(name, domain string, req mcp.CallToolRequest) c
 
 	if req.GetBool("proxy_enabled", false) {
 		backend := req.GetString("proxy_backend", "")
-		if backend != "" {
+		staticRoot := req.GetString("proxy_static_root", "")
+		if backend != "" || staticRoot != "" {
 			svc.Proxy = &config.ProxyConfig{
 				Backend:      backend,
+				StaticRoot:   staticRoot,
 				InternalOnly: req.GetBool("internal_only", false),
 			}
 			if checkPath := req.GetString("health_check_path", ""); checkPath != "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -218,7 +218,7 @@ type Server struct {
 	sync           *SyncBroadcaster
 	health         *HealthStatus
 	metrics        *integration.Detector // Prometheus metrics discovery (pull integration)
-	static         *staticServer         // loopback file server for static-folder services
+	static         *staticSupervisor     // supervises the unprivileged static file server child
 
 	configSharesMu sync.Mutex
 	configShares   map[string]*configShare // token -> share
@@ -399,7 +399,7 @@ func NewWithConfig(cfg *config.Config, configPath string, dryRun bool, version s
 		sync:         NewSyncBroadcaster(),
 		health:       &HealthStatus{healthy: true},
 		metrics:      integration.NewDetector(),
-		static:       newStaticServer(),
+		static:       newStaticSupervisor(cfg.StaticServeAddr(), dryRun),
 		configShares: make(map[string]*configShare),
 		joinTokens:   newJoinTokenStore(),
 	}
@@ -1378,11 +1378,9 @@ func (s *Server) RunWithTokenCallback(onNewToken func(token string)) error {
 	s.monitor.Start()
 	slog.Info("service monitor started")
 
-	// Start the loopback static file server for static-folder services.
-	// Loopback-only; skip under dry-run (no real network binds).
-	if !s.dryRun {
-		s.static.Start(s.cfg().StaticServeAddr())
-	}
+	// Start the static file server (unprivileged child process; see
+	// staticSupervisor). No-op under dry-run.
+	s.static.Start()
 
 	// Start unattended cert renewal (Phase 2 prereq)
 	s.startCertRenewal()
@@ -1424,6 +1422,7 @@ func (s *Server) RunWithTokenCallback(onNewToken func(token string)) error {
 		return err
 	case <-sig:
 		slog.Info("shutting down (draining in-flight requests)")
+		s.static.Stop()
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		return server.Shutdown(ctx)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1032,7 +1032,20 @@ func (s *Server) setupRoutes() *http.ServeMux {
 
 // handler returns the fully-wrapped HTTP handler (mux + middlewares).
 func (s *Server) handler() http.Handler {
-	return s.nonPrimaryGuardMiddleware(s.setupRoutes())
+	return securityHeadersMiddleware(s.nonPrimaryGuardMiddleware(s.setupRoutes()))
+}
+
+// securityHeadersMiddleware sets baseline security response headers on the
+// admin UI/API. No CSP — the React SPA would need a tailored policy, tracked
+// separately; these are the safe, app-agnostic headers.
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "same-origin")
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) ensureServicesRunning() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -218,6 +218,7 @@ type Server struct {
 	sync           *SyncBroadcaster
 	health         *HealthStatus
 	metrics        *integration.Detector // Prometheus metrics discovery (pull integration)
+	static         *staticServer         // loopback file server for static-folder services
 
 	configSharesMu sync.Mutex
 	configShares   map[string]*configShare // token -> share
@@ -398,10 +399,12 @@ func NewWithConfig(cfg *config.Config, configPath string, dryRun bool, version s
 		sync:         NewSyncBroadcaster(),
 		health:       &HealthStatus{healthy: true},
 		metrics:      integration.NewDetector(),
+		static:       newStaticServer(),
 		configShares: make(map[string]*configShare),
 		joinTokens:   newJoinTokenStore(),
 	}
 	s.config.Store(cfg)
+	s.static.Rebuild(cfg)
 
 	return s, nil
 }
@@ -1361,6 +1364,12 @@ func (s *Server) RunWithTokenCallback(onNewToken func(token string)) error {
 	// Start service health monitor
 	s.monitor.Start()
 	slog.Info("service monitor started")
+
+	// Start the loopback static file server for static-folder services.
+	// Loopback-only; skip under dry-run (no real network binds).
+	if !s.dryRun {
+		s.static.Start(s.cfg().StaticServeAddr())
+	}
 
 	// Start unattended cert renewal (Phase 2 prereq)
 	s.startCertRenewal()

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -10,22 +10,35 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/iodesystems/homelab-horizon/internal/config"
 )
 
-// staticSite is the resolved serving config for one host.
+// staticSite is the serving config for one host. It is also the JSON wire form
+// sent from the root parent process to the unprivileged child over its stdin,
+// hence the exported, tagged fields.
 type staticSite struct {
-	root string // document root directory
-	spa  bool   // serve index.html for unknown non-asset paths (client-side routing)
+	Root string `json:"root"` // document root directory
+	SPA  bool   `json:"spa"`  // serve index.html for unknown non-asset paths (client-side routing)
 }
 
-// staticServer serves per-service static folders on an internal loopback
-// listener. HAProxy routes a static-folder service's domains here (see
-// Config.StaticServeAddr); the document root is selected by the request Host
-// header. The listener binds to 127.0.0.1 only, so it is reachable solely by
-// the local HAProxy — never directly from the network.
+// deriveStaticSites builds the host->site map from the services in cfg.
+func deriveStaticSites(cfg *config.Config) map[string]staticSite {
+	sites := make(map[string]staticSite)
+	for _, svc := range cfg.Services {
+		if svc.Proxy == nil || svc.Proxy.StaticRoot == "" {
+			continue
+		}
+		for _, d := range svc.Domains {
+			sites[strings.ToLower(d)] = staticSite{Root: svc.Proxy.StaticRoot, SPA: svc.Proxy.SPA}
+		}
+	}
+	return sites
+}
+
+// staticServer is the HTTP handler that serves per-service static folders. The
+// document root is selected by the request Host header. It holds no privileges
+// of its own; in production it runs inside the unprivileged child process.
 type staticServer struct {
 	mu    sync.RWMutex
 	sites map[string]staticSite // lowercased host -> serving config
@@ -35,21 +48,16 @@ func newStaticServer() *staticServer {
 	return &staticServer{sites: make(map[string]staticSite)}
 }
 
-// Rebuild refreshes the host->site map from the current config. Safe to call on
-// every config sync; the swap is atomic for in-flight requests.
-func (ss *staticServer) Rebuild(cfg *config.Config) {
-	sites := make(map[string]staticSite)
-	for _, svc := range cfg.Services {
-		if svc.Proxy == nil || svc.Proxy.StaticRoot == "" {
-			continue
-		}
-		for _, d := range svc.Domains {
-			sites[strings.ToLower(d)] = staticSite{root: svc.Proxy.StaticRoot, spa: svc.Proxy.SPA}
-		}
-	}
+// setSites atomically swaps the host->site map for in-flight requests.
+func (ss *staticServer) setSites(sites map[string]staticSite) {
 	ss.mu.Lock()
 	ss.sites = sites
 	ss.mu.Unlock()
+}
+
+// Rebuild refreshes the map from cfg (used in-process / by tests).
+func (ss *staticServer) Rebuild(cfg *config.Config) {
+	ss.setSites(deriveStaticSites(cfg))
 }
 
 // siteFor returns the serving config for the given request host, stripping any
@@ -107,9 +115,9 @@ func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, site s
 
 	// os.Root pins all opens inside the document root, rejecting symlink/".."
 	// escape even though hz runs as root.
-	root, err := os.OpenRoot(site.root)
+	root, err := os.OpenRoot(site.Root)
 	if err != nil {
-		slog.Warn("static: cannot open root", "dir", site.root, "err", err)
+		slog.Warn("static: cannot open root", "dir", site.Root, "err", err)
 		ss.writeError(w, http.StatusInternalServerError)
 		return
 	}
@@ -119,7 +127,7 @@ func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, site s
 	if err != nil {
 		// SPA fallback: a browser refresh on a client-side route (no file
 		// extension) serves index.html so the app boots and routes itself.
-		if site.spa && path.Ext(name) == "" {
+		if site.SPA && path.Ext(name) == "" {
 			if idx, idxInfo, idxErr := openServable(root, "index.html"); idxErr == nil {
 				serveContent(w, r, "index.html", idxInfo, idx)
 				_ = idx.Close()
@@ -240,26 +248,3 @@ const errorPageTmpl = `<!DOCTYPE html>
 <style>html,body{height:100%%;margin:0}body{font:16px/1.5 system-ui,-apple-system,sans-serif;background:#0d1117;color:#e6edf3;display:grid;place-items:center}div{text-align:center}h1{font-size:3.5rem;margin:0 0 .2em}p{color:#9da7b3;margin:0}</style>
 </head><body><div><h1>%d</h1><p>%s</p></div></body></html>
 `
-
-// Start binds the loopback listener and serves in the background. A bind
-// failure is logged and non-fatal: only static-folder services are affected,
-// and the rest of hz continues to run.
-func (ss *staticServer) Start(addr string) {
-	srv := &http.Server{
-		Addr:              addr,
-		Handler:           ss,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
-	}
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		slog.Warn("static file server: could not bind, static services disabled", "addr", addr, "err", err)
-		return
-	}
-	slog.Info("static file server listening", "addr", addr)
-	go func() {
-		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
-			slog.Warn("static file server stopped", "err", err)
-		}
-	}()
-}

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/iodesystems/homelab-horizon/internal/config"
+)
+
+// staticServer serves per-service static folders on an internal loopback
+// listener. HAProxy routes a static-folder service's domains here (see
+// Config.StaticServeAddr); the document root is selected by the request Host
+// header. The listener binds to 127.0.0.1 only, so it is reachable solely by
+// the local HAProxy — never directly from the network.
+type staticServer struct {
+	mu    sync.RWMutex
+	roots map[string]string // lowercased host -> filesystem root directory
+}
+
+func newStaticServer() *staticServer {
+	return &staticServer{roots: make(map[string]string)}
+}
+
+// Rebuild refreshes the host->root map from the current config. Safe to call on
+// every config sync; the swap is atomic for in-flight requests.
+func (ss *staticServer) Rebuild(cfg *config.Config) {
+	roots := make(map[string]string)
+	for _, svc := range cfg.Services {
+		if svc.Proxy == nil || svc.Proxy.StaticRoot == "" {
+			continue
+		}
+		for _, d := range svc.Domains {
+			roots[strings.ToLower(d)] = svc.Proxy.StaticRoot
+		}
+	}
+	ss.mu.Lock()
+	ss.roots = roots
+	ss.mu.Unlock()
+}
+
+// rootFor returns the document root configured for the given request host,
+// stripping any port. ok is false when no static service claims the host.
+func (ss *staticServer) rootFor(host string) (string, bool) {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	root, ok := ss.roots[strings.ToLower(host)]
+	return root, ok
+}
+
+func (ss *staticServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	root, ok := ss.rootFor(r.Host)
+	if !ok {
+		http.Error(w, "no static service for host", http.StatusNotFound)
+		return
+	}
+	// http.Dir + FileServer reject path-traversal ("../") and serve index.html
+	// for directory requests.
+	http.FileServer(http.Dir(root)).ServeHTTP(w, r)
+}
+
+// Start binds the loopback listener and serves in the background. A bind
+// failure is logged and non-fatal: only static-folder services are affected,
+// and the rest of hz continues to run.
+func (ss *staticServer) Start(addr string) {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           ss,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Warn("static file server: could not bind, static services disabled", "addr", addr, "err", err)
+		return
+	}
+	slog.Info("static file server listening", "addr", addr)
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			slog.Warn("static file server stopped", "err", err)
+		}
+	}()
+}

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -135,7 +135,14 @@ func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, site s
 				return
 			}
 		}
-		ss.notFound(w, r, root)
+		// Missing file -> 404. Anything else (exists but unreadable by the
+		// unprivileged user, I/O error) is a server-side problem -> 500.
+		if os.IsNotExist(err) {
+			ss.errorResponse(w, r, root, http.StatusNotFound, "404.html")
+		} else {
+			slog.Warn("static: serving file failed", "name", name, "err", err)
+			ss.errorResponse(w, r, root, http.StatusInternalServerError, "5xx.html")
+		}
 		return
 	}
 	defer func() { _ = f.Close() }()
@@ -143,14 +150,16 @@ func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, site s
 	serveContent(w, r, info.Name(), info, f)
 }
 
-// notFound serves the site's own 404.html (with a 404 status) when present,
-// falling back to the built-in error page.
-func (ss *staticServer) notFound(w http.ResponseWriter, r *http.Request, root *os.Root) {
-	if f, err := root.Open("404.html"); err == nil {
+// errorResponse serves the site's own error page (page, e.g. 404.html or
+// 5xx.html) from root with the given status when present, falling back to the
+// built-in page. Note: when the whole root is unopenable there is no page to
+// read, so that case always uses the built-in page.
+func (ss *staticServer) errorResponse(w http.ResponseWriter, r *http.Request, root *os.Root, code int, page string) {
+	if f, err := root.Open(page); err == nil {
 		info, statErr := f.Stat()
 		if statErr == nil && !info.IsDir() {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(code)
 			if r.Method != http.MethodHead {
 				_, _ = io.Copy(w, f)
 			}
@@ -159,7 +168,7 @@ func (ss *staticServer) notFound(w http.ResponseWriter, r *http.Request, root *o
 		}
 		_ = f.Close()
 	}
-	ss.writeError(w, http.StatusNotFound)
+	ss.writeError(w, code)
 }
 
 // openServable opens name within root, resolving a directory to its index.html.

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -60,9 +62,72 @@ func (ss *staticServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no static service for host", http.StatusNotFound)
 		return
 	}
-	// http.Dir + FileServer reject path-traversal ("../") and serve index.html
-	// for directory requests.
-	http.FileServer(http.Dir(root)).ServeHTTP(w, r)
+	ss.serveFile(w, r, root)
+}
+
+// serveFile serves a single file from dir for the request. Because hz runs as
+// root, this handler is deliberately strict beyond the loopback bind:
+//   - os.Root confines every open to dir — no "../" and no symlink can escape
+//     it, so a stray symlink inside the root can't leak /etc/shadow et al.
+//   - hidden path segments (.git, .env, .ssh, dotfiles) are never served.
+//   - directories are never listed; a directory serves its index.html or 404s.
+func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, dir string) {
+	upath := r.URL.Path
+	if !strings.HasPrefix(upath, "/") {
+		upath = "/" + upath
+	}
+	name := strings.TrimPrefix(path.Clean(upath), "/")
+
+	// Refuse any hidden segment outright (also covers a residual "..").
+	for _, seg := range strings.Split(name, "/") {
+		if seg != "." && strings.HasPrefix(seg, ".") {
+			http.NotFound(w, r)
+			return
+		}
+	}
+	if name == "" {
+		name = "."
+	}
+
+	// os.Root pins all subsequent opens inside dir, rejecting symlink/".." escape.
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		slog.Warn("static: cannot open root", "dir", dir, "err", err)
+		http.NotFound(w, r)
+		return
+	}
+	defer func() { _ = root.Close() }()
+
+	f, err := root.Open(name)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	// No directory listing: a directory request must resolve to its index.html.
+	if info.IsDir() {
+		_ = f.Close()
+		f, err = root.Open(path.Join(name, "index.html"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		info, err = f.Stat()
+		if err != nil || info.IsDir() {
+			http.NotFound(w, r)
+			return
+		}
+	}
+
+	// ServeContent handles Content-Type sniffing, Range, and If-Modified-Since.
+	http.ServeContent(w, r, info.Name(), info.ModTime(), f)
 }
 
 // Start binds the loopback listener and serves in the background. A bind

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"mime"
 	"net"
@@ -134,12 +135,31 @@ func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, site s
 				return
 			}
 		}
-		ss.writeError(w, http.StatusNotFound)
+		ss.notFound(w, r, root)
 		return
 	}
 	defer func() { _ = f.Close() }()
 
 	serveContent(w, r, info.Name(), info, f)
+}
+
+// notFound serves the site's own 404.html (with a 404 status) when present,
+// falling back to the built-in error page.
+func (ss *staticServer) notFound(w http.ResponseWriter, r *http.Request, root *os.Root) {
+	if f, err := root.Open("404.html"); err == nil {
+		info, statErr := f.Stat()
+		if statErr == nil && !info.IsDir() {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusNotFound)
+			if r.Method != http.MethodHead {
+				_, _ = io.Copy(w, f)
+			}
+			_ = f.Close()
+			return
+		}
+		_ = f.Close()
+	}
+	ss.writeError(w, http.StatusNotFound)
 }
 
 // openServable opens name within root, resolving a directory to its index.html.

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"fmt"
 	"log/slog"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -13,6 +15,12 @@ import (
 	"github.com/iodesystems/homelab-horizon/internal/config"
 )
 
+// staticSite is the resolved serving config for one host.
+type staticSite struct {
+	root string // document root directory
+	spa  bool   // serve index.html for unknown non-asset paths (client-side routing)
+}
+
 // staticServer serves per-service static folders on an internal loopback
 // listener. HAProxy routes a static-folder service's domains here (see
 // Config.StaticServeAddr); the document root is selected by the request Host
@@ -20,115 +28,218 @@ import (
 // the local HAProxy — never directly from the network.
 type staticServer struct {
 	mu    sync.RWMutex
-	roots map[string]string // lowercased host -> filesystem root directory
+	sites map[string]staticSite // lowercased host -> serving config
 }
 
 func newStaticServer() *staticServer {
-	return &staticServer{roots: make(map[string]string)}
+	return &staticServer{sites: make(map[string]staticSite)}
 }
 
-// Rebuild refreshes the host->root map from the current config. Safe to call on
+// Rebuild refreshes the host->site map from the current config. Safe to call on
 // every config sync; the swap is atomic for in-flight requests.
 func (ss *staticServer) Rebuild(cfg *config.Config) {
-	roots := make(map[string]string)
+	sites := make(map[string]staticSite)
 	for _, svc := range cfg.Services {
 		if svc.Proxy == nil || svc.Proxy.StaticRoot == "" {
 			continue
 		}
 		for _, d := range svc.Domains {
-			roots[strings.ToLower(d)] = svc.Proxy.StaticRoot
+			sites[strings.ToLower(d)] = staticSite{root: svc.Proxy.StaticRoot, spa: svc.Proxy.SPA}
 		}
 	}
 	ss.mu.Lock()
-	ss.roots = roots
+	ss.sites = sites
 	ss.mu.Unlock()
 }
 
-// rootFor returns the document root configured for the given request host,
-// stripping any port. ok is false when no static service claims the host.
-func (ss *staticServer) rootFor(host string) (string, bool) {
+// siteFor returns the serving config for the given request host, stripping any
+// port. ok is false when no static service claims the host.
+func (ss *staticServer) siteFor(host string) (staticSite, bool) {
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
 	ss.mu.RLock()
 	defer ss.mu.RUnlock()
-	root, ok := ss.roots[strings.ToLower(host)]
-	return root, ok
+	s, ok := ss.sites[strings.ToLower(host)]
+	return s, ok
 }
 
 func (ss *staticServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	root, ok := ss.rootFor(r.Host)
-	if !ok {
-		http.Error(w, "no static service for host", http.StatusNotFound)
+	// Security headers on every response, including errors. nosniff is the
+	// important one — it stops a served file from being reinterpreted as a
+	// different (executable) type regardless of our Content-Type.
+	h := w.Header()
+	h.Set("X-Content-Type-Options", "nosniff")
+	h.Set("X-Frame-Options", "DENY")
+	h.Set("Referrer-Policy", "same-origin")
+
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		h.Set("Allow", "GET, HEAD")
+		ss.writeError(w, http.StatusMethodNotAllowed)
 		return
 	}
-	ss.serveFile(w, r, root)
+
+	site, ok := ss.siteFor(r.Host)
+	if !ok {
+		ss.writeError(w, http.StatusNotFound)
+		return
+	}
+	ss.serveFile(w, r, site)
 }
 
-// serveFile serves a single file from dir for the request. Because hz runs as
-// root, this handler is deliberately strict beyond the loopback bind:
-//   - os.Root confines every open to dir — no "../" and no symlink can escape
-//     it, so a stray symlink inside the root can't leak /etc/shadow et al.
+// serveFile serves a single file for the request. Because hz runs as root (for
+// now), this handler is deliberately strict beyond the loopback bind:
+//   - os.Root confines every open to the document root — no "../" and no
+//     symlink can escape it.
 //   - hidden path segments (.git, .env, .ssh, dotfiles) are never served.
 //   - directories are never listed; a directory serves its index.html or 404s.
-func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, dir string) {
-	upath := r.URL.Path
-	if !strings.HasPrefix(upath, "/") {
-		upath = "/" + upath
-	}
-	name := strings.TrimPrefix(path.Clean(upath), "/")
+//   - Content-Type is set explicitly from the extension (no content sniffing).
+func (ss *staticServer) serveFile(w http.ResponseWriter, r *http.Request, site staticSite) {
+	name := cleanRequestPath(r.URL.Path)
 
 	// Refuse any hidden segment outright (also covers a residual "..").
 	for _, seg := range strings.Split(name, "/") {
 		if seg != "." && strings.HasPrefix(seg, ".") {
-			http.NotFound(w, r)
+			ss.writeError(w, http.StatusNotFound)
 			return
 		}
 	}
-	if name == "" {
-		name = "."
-	}
 
-	// os.Root pins all subsequent opens inside dir, rejecting symlink/".." escape.
-	root, err := os.OpenRoot(dir)
+	// os.Root pins all opens inside the document root, rejecting symlink/".."
+	// escape even though hz runs as root.
+	root, err := os.OpenRoot(site.root)
 	if err != nil {
-		slog.Warn("static: cannot open root", "dir", dir, "err", err)
-		http.NotFound(w, r)
+		slog.Warn("static: cannot open root", "dir", site.root, "err", err)
+		ss.writeError(w, http.StatusInternalServerError)
 		return
 	}
 	defer func() { _ = root.Close() }()
 
-	f, err := root.Open(name)
+	f, info, err := openServable(root, name)
 	if err != nil {
-		http.NotFound(w, r)
+		// SPA fallback: a browser refresh on a client-side route (no file
+		// extension) serves index.html so the app boots and routes itself.
+		if site.spa && path.Ext(name) == "" {
+			if idx, idxInfo, idxErr := openServable(root, "index.html"); idxErr == nil {
+				serveContent(w, r, "index.html", idxInfo, idx)
+				_ = idx.Close()
+				return
+			}
+		}
+		ss.writeError(w, http.StatusNotFound)
 		return
 	}
 	defer func() { _ = f.Close() }()
 
+	serveContent(w, r, info.Name(), info, f)
+}
+
+// openServable opens name within root, resolving a directory to its index.html.
+// It never returns a directory — callers get a regular file or an error, so
+// there is no directory listing.
+func openServable(root *os.Root, name string) (*os.File, os.FileInfo, error) {
+	if name == "" {
+		name = "."
+	}
+	f, err := root.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
 	info, err := f.Stat()
 	if err != nil {
-		http.NotFound(w, r)
-		return
+		_ = f.Close()
+		return nil, nil, err
 	}
-
-	// No directory listing: a directory request must resolve to its index.html.
 	if info.IsDir() {
 		_ = f.Close()
 		f, err = root.Open(path.Join(name, "index.html"))
 		if err != nil {
-			http.NotFound(w, r)
-			return
+			return nil, nil, err
 		}
 		info, err = f.Stat()
-		if err != nil || info.IsDir() {
-			http.NotFound(w, r)
-			return
+		if err != nil {
+			_ = f.Close()
+			return nil, nil, err
+		}
+		if info.IsDir() {
+			_ = f.Close()
+			return nil, nil, fmt.Errorf("index.html is a directory")
 		}
 	}
-
-	// ServeContent handles Content-Type sniffing, Range, and If-Modified-Since.
-	http.ServeContent(w, r, info.Name(), info.ModTime(), f)
+	return f, info, nil
 }
+
+// serveContent sets an explicit Content-Type from the file extension before
+// delegating to http.ServeContent (which then handles Range and
+// If-Modified-Since). Setting it ourselves sidesteps content-sniffing and
+// system mime.types inconsistencies.
+func serveContent(w http.ResponseWriter, r *http.Request, name string, info os.FileInfo, f *os.File) {
+	if ct := contentType(name); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	}
+	http.ServeContent(w, r, name, info.ModTime(), f)
+}
+
+// staticContentTypes pins the Content-Type for common web assets so serving
+// does not depend on the host's /etc/mime.types. mime.TypeByExtension is the
+// fallback for anything not listed.
+var staticContentTypes = map[string]string{
+	".html":  "text/html; charset=utf-8",
+	".htm":   "text/html; charset=utf-8",
+	".css":   "text/css; charset=utf-8",
+	".js":    "text/javascript; charset=utf-8",
+	".mjs":   "text/javascript; charset=utf-8",
+	".json":  "application/json",
+	".map":   "application/json",
+	".xml":   "application/xml",
+	".txt":   "text/plain; charset=utf-8",
+	".svg":   "image/svg+xml",
+	".png":   "image/png",
+	".jpg":   "image/jpeg",
+	".jpeg":  "image/jpeg",
+	".gif":   "image/gif",
+	".webp":  "image/webp",
+	".avif":  "image/avif",
+	".ico":   "image/x-icon",
+	".woff":  "font/woff",
+	".woff2": "font/woff2",
+	".ttf":   "font/ttf",
+	".wasm":  "application/wasm",
+	".pdf":   "application/pdf",
+}
+
+func contentType(name string) string {
+	ext := strings.ToLower(path.Ext(name))
+	if ct, ok := staticContentTypes[ext]; ok {
+		return ct
+	}
+	return mime.TypeByExtension(ext)
+}
+
+// cleanRequestPath normalizes the URL path to a root-relative, cleaned name
+// with no leading slash (e.g. "/a/../b/" -> "b").
+func cleanRequestPath(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return strings.TrimPrefix(path.Clean(p), "/")
+}
+
+// writeError renders the static server's standard error page for code.
+func (ss *staticServer) writeError(w http.ResponseWriter, code int) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(code)
+	text := http.StatusText(code)
+	_, _ = fmt.Fprintf(w, errorPageTmpl, code, text, code, text)
+}
+
+const errorPageTmpl = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>%d %s</title>
+<style>html,body{height:100%%;margin:0}body{font:16px/1.5 system-ui,-apple-system,sans-serif;background:#0d1117;color:#e6edf3;display:grid;place-items:center}div{text-align:center}h1{font-size:3.5rem;margin:0 0 .2em}p{color:#9da7b3;margin:0}</style>
+</head><body><div><h1>%d</h1><p>%s</p></div></body></html>
+`
 
 // Start binds the loopback listener and serves in the background. A bind
 // failure is logged and non-fatal: only static-folder services are affected,
@@ -138,6 +249,7 @@ func (ss *staticServer) Start(addr string) {
 		Addr:              addr,
 		Handler:           ss,
 		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/internal/server/static_child.go
+++ b/internal/server/static_child.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+)
+
+// StaticServerEnvAddr is the environment variable hz sets when re-execing
+// itself as the unprivileged static-file-server child. Its value is the
+// loopback address the child binds.
+const StaticServerEnvAddr = "HZ_STATIC_SERVER_ADDR"
+
+// RunStaticServerChild runs the unprivileged static file server. hz re-execs
+// itself with StaticServerEnvAddr set, dropped to an unprivileged user, and
+// this is the child's entire job — so even a bug in the file handler cannot
+// read files the unprivileged user can't. The host->site map arrives as
+// newline-delimited JSON on stdin (pushed by the parent on each config sync);
+// when stdin closes (parent gone) the child shuts down.
+func RunStaticServerChild(addr string) {
+	ss := newStaticServer()
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           ss,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	go func() {
+		ss.consumeSites(os.Stdin)
+		// Parent closed the pipe (shutting down): drain and exit.
+		_ = srv.Shutdown(context.Background())
+	}()
+
+	slog.Info("static file server child listening", "addr", addr, "uid", os.Geteuid())
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		slog.Error("static file server child failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+// consumeSites reads newline-delimited JSON host->site maps from r and applies
+// each to ss, returning when r is exhausted.
+func (ss *staticServer) consumeSites(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024) // allow large maps
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var sites map[string]staticSite
+		if err := json.Unmarshal(line, &sites); err != nil {
+			slog.Warn("static child: bad site map", "err", err)
+			continue
+		}
+		ss.setSites(sites)
+	}
+}

--- a/internal/server/static_supervisor.go
+++ b/internal/server/static_supervisor.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/iodesystems/homelab-horizon/internal/config"
+)
+
+// staticSupervisor manages the unprivileged static-file-server child process.
+// It owns the current host->site map and pushes it to the child over a pipe on
+// every config change; if the child dies it is respawned and re-seeded.
+//
+// The point is privilege separation: hz runs as root, but files must never be
+// served by a root process. In production the supervisor spawns a child dropped
+// to an unprivileged user. In dev (not root) there is nothing to drop, so it
+// serves in-process. If it is root but cannot drop, it refuses to serve rather
+// than serve files as root.
+type staticSupervisor struct {
+	addr   string
+	dryRun bool
+
+	mu      sync.Mutex
+	sites   map[string]staticSite
+	stdin   io.WriteCloser // pipe to the running child; nil when none
+	stopped bool
+	inproc  *staticServer // set only in the in-process (dev) fallback
+}
+
+func newStaticSupervisor(addr string, dryRun bool) *staticSupervisor {
+	return &staticSupervisor{addr: addr, dryRun: dryRun, sites: map[string]staticSite{}}
+}
+
+// Rebuild stores the latest map and pushes it to a running child / in-proc server.
+func (s *staticSupervisor) Rebuild(cfg *config.Config) {
+	sites := deriveStaticSites(cfg)
+	s.mu.Lock()
+	s.sites = sites
+	w := s.stdin
+	inproc := s.inproc
+	s.mu.Unlock()
+
+	if inproc != nil {
+		inproc.setSites(sites)
+	}
+	if w != nil {
+		s.push(w, sites)
+	}
+}
+
+func (s *staticSupervisor) push(w io.Writer, sites map[string]staticSite) {
+	b, err := json.Marshal(sites)
+	if err != nil {
+		slog.Warn("static: marshal sites", "err", err)
+		return
+	}
+	if _, err := w.Write(append(b, '\n')); err != nil {
+		slog.Warn("static: push to child failed", "err", err)
+	}
+}
+
+// Start launches the static file server according to the environment:
+//   - dry-run: no-op.
+//   - not root: serve in-process (already unprivileged — dev/test).
+//   - root: spawn an unprivileged child. If privileges can't be dropped, refuse
+//     to serve (fail closed) rather than serve files as root.
+func (s *staticSupervisor) Start() {
+	if s.dryRun {
+		return
+	}
+	if os.Geteuid() != 0 {
+		s.startInProcess()
+		return
+	}
+	cred, err := unprivilegedCredential()
+	if err != nil {
+		slog.Error("static: cannot drop privileges — static services DISABLED (refusing to serve files as root)", "err", err)
+		return
+	}
+	go s.superviseChild(cred)
+}
+
+func (s *staticSupervisor) startInProcess() {
+	ss := newStaticServer()
+	s.mu.Lock()
+	ss.setSites(s.sites)
+	s.inproc = ss
+	s.mu.Unlock()
+
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		slog.Warn("static: in-process bind failed, static services disabled", "addr", s.addr, "err", err)
+		return
+	}
+	srv := &http.Server{Addr: s.addr, Handler: ss, ReadHeaderTimeout: 10 * time.Second, IdleTimeout: 60 * time.Second}
+	slog.Warn("static file server running in-process (not root; dev mode)", "addr", s.addr)
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			slog.Warn("static in-process server stopped", "err", err)
+		}
+	}()
+}
+
+// superviseChild (re-)spawns the child and restarts it with backoff if it exits
+// unexpectedly. Each spawn is re-seeded with the current map.
+func (s *staticSupervisor) superviseChild(cred *syscall.Credential) {
+	exe, err := os.Executable()
+	if err != nil {
+		slog.Error("static: cannot resolve own executable", "err", err)
+		return
+	}
+	backoff := time.Second
+	for {
+		s.mu.Lock()
+		stopped := s.stopped
+		s.mu.Unlock()
+		if stopped {
+			return
+		}
+
+		start := time.Now()
+		if err := s.runChildOnce(exe, cred); err != nil {
+			slog.Warn("static child exited", "err", err)
+		}
+
+		// Back off only on rapid failure to avoid a respawn spin.
+		if time.Since(start) < 2*time.Second {
+			time.Sleep(backoff)
+			if backoff < 30*time.Second {
+				backoff *= 2
+			}
+		} else {
+			backoff = time.Second
+		}
+	}
+}
+
+func (s *staticSupervisor) runChildOnce(exe string, cred *syscall.Credential) error {
+	cmd := exec.Command(exe)
+	// Minimal env — don't leak the parent's environment (it may hold secrets)
+	// into the less-trusted child.
+	cmd.Env = []string{StaticServerEnvAddr + "=" + s.addr}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: cred}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return err
+	}
+	slog.Info("static file server child started", "pid", cmd.Process.Pid, "uid", cred.Uid, "addr", s.addr)
+
+	// Register the pipe and seed the child with the current map.
+	s.mu.Lock()
+	s.stdin = stdin
+	sites := s.sites
+	s.mu.Unlock()
+	s.push(stdin, sites)
+
+	err = cmd.Wait()
+
+	s.mu.Lock()
+	s.stdin = nil
+	s.mu.Unlock()
+	_ = stdin.Close()
+	return err
+}
+
+// Stop terminates the child (if any) and prevents further restarts. Closing the
+// child's stdin makes it shut its listener down and exit.
+func (s *staticSupervisor) Stop() {
+	s.mu.Lock()
+	s.stopped = true
+	w := s.stdin
+	s.stdin = nil
+	s.mu.Unlock()
+	if w != nil {
+		_ = w.Close()
+	}
+}
+
+// unprivilegedCredential resolves the "nobody" user to a process credential for
+// the child.
+func unprivilegedCredential() (*syscall.Credential, error) {
+	u, err := user.Lookup("nobody")
+	if err != nil {
+		return nil, fmt.Errorf("lookup user nobody: %w", err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("parse nobody uid %q: %w", u.Uid, err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return nil, fmt.Errorf("parse nobody gid %q: %w", u.Gid, err)
+	}
+	return &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}, nil
+}

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -183,6 +183,41 @@ func TestStaticServer_RebuildReplaces(t *testing.T) {
 	}
 }
 
+func TestDeriveStaticSites(t *testing.T) {
+	sites := deriveStaticSites(&config.Config{Services: []config.Service{
+		{Name: "docs", Domains: []string{"docs.example.com", "www.example.com"},
+			Proxy: &config.ProxyConfig{StaticRoot: "/srv/docs", SPA: true}},
+		{Name: "api", Domains: []string{"api.example.com"},
+			Proxy: &config.ProxyConfig{Backend: "127.0.0.1:9000"}},
+	}})
+	if len(sites) != 2 {
+		t.Fatalf("want 2 static hosts, got %d: %+v", len(sites), sites)
+	}
+	if s := sites["docs.example.com"]; s.Root != "/srv/docs" || !s.SPA {
+		t.Errorf("docs site = %+v, want {/srv/docs true}", s)
+	}
+	if _, ok := sites["api.example.com"]; ok {
+		t.Error("proxied service must not appear as a static site")
+	}
+}
+
+// consumeSites applies newline-delimited JSON maps from the parent; the last
+// one wins (atomic replace), which is the child's update path.
+func TestStaticServer_ConsumeSites(t *testing.T) {
+	ss := newStaticServer()
+	input := `{"a.example.com":{"root":"/srv/a"}}` + "\n" +
+		`{"b.example.com":{"root":"/srv/b","spa":true}}` + "\n"
+	ss.consumeSites(strings.NewReader(input))
+
+	if _, ok := ss.siteFor("a.example.com"); ok {
+		t.Error("a.example.com should be gone after the second map replaced it")
+	}
+	site, ok := ss.siteFor("b.example.com")
+	if !ok || site.Root != "/srv/b" || !site.SPA {
+		t.Errorf("b site = %+v ok=%v, want {/srv/b true}", site, ok)
+	}
+}
+
 func TestStaticServer_SPAFallback(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("APP"), 0644); err != nil {

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -174,11 +174,98 @@ func TestStaticServer_RebuildReplaces(t *testing.T) {
 	ss.Rebuild(&config.Config{Services: []config.Service{
 		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
 	}})
-	if _, ok := ss.rootFor("a.example.com"); !ok {
+	if _, ok := ss.siteFor("a.example.com"); !ok {
 		t.Fatal("expected a.example.com after first rebuild")
 	}
 	ss.Rebuild(&config.Config{Services: nil})
-	if _, ok := ss.rootFor("a.example.com"); ok {
+	if _, ok := ss.siteFor("a.example.com"); ok {
 		t.Error("expected a.example.com to be gone after rebuild with no services")
+	}
+}
+
+func TestStaticServer_SPAFallback(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("APP"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "app.js"), []byte("code"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root, SPA: true}},
+	}})
+
+	tests := []struct {
+		name     string
+		path     string
+		wantCode int
+		wantBody string
+	}{
+		{"client route falls back to index", "/dashboard/settings", http.StatusOK, "APP"},
+		{"existing asset served normally", "/app.js", http.StatusOK, "code"},
+		{"missing asset still 404s (not index)", "/missing.js", http.StatusNotFound, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Host = "a.example.com"
+			rec := httptest.NewRecorder()
+			ss.ServeHTTP(rec, req)
+			if rec.Code != tt.wantCode {
+				t.Fatalf("code = %d, want %d", rec.Code, tt.wantCode)
+			}
+			if tt.wantBody != "" && rec.Body.String() != tt.wantBody {
+				t.Errorf("body = %q, want %q", rec.Body.String(), tt.wantBody)
+			}
+		})
+	}
+
+	// Without the SPA flag, an unknown client route 404s.
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("non-SPA unknown route: code = %d, want 404", rec.Code)
+	}
+}
+
+func TestStaticServer_HardeningHeaders(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<h1>hi</h1>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "app.js"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+
+	// nosniff present and explicit content-type by extension.
+	req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("nosniff = %q, want nosniff", got)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/javascript") {
+		t.Errorf("content-type = %q, want text/javascript", ct)
+	}
+
+	// Non-GET/HEAD is rejected.
+	req = httptest.NewRequest(http.MethodPost, "/index.html", nil)
+	req.Host = "a.example.com"
+	rec = httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST code = %d, want 405", rec.Code)
 	}
 }

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -270,6 +270,49 @@ func TestStaticServer_SPAFallback(t *testing.T) {
 	}
 }
 
+// A site-provided 404.html is served (with a 404 status) for not-found paths;
+// otherwise the built-in error page is used.
+func TestStaticServer_Custom404(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("home"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "404.html"), []byte("custom not found"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", rec.Code)
+	}
+	if rec.Body.String() != "custom not found" {
+		t.Errorf("body = %q, want custom 404.html content", rec.Body.String())
+	}
+
+	// A site without 404.html falls back to the built-in page.
+	root2 := t.TempDir()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "b", Domains: []string{"b.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root2}},
+	}})
+	req = httptest.NewRequest(http.MethodGet, "/missing", nil)
+	req.Host = "b.example.com"
+	rec = httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("fallback code = %d, want 404", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "Not Found") {
+		t.Errorf("built-in page missing status text: %q", rec.Body.String())
+	}
+}
+
 func TestStaticServer_HardeningHeaders(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<h1>hi</h1>"), 0644); err != nil {

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -313,6 +313,42 @@ func TestStaticServer_Custom404(t *testing.T) {
 	}
 }
 
+// An existing-but-unreadable file is a server-side error (500), and the site's
+// 5xx.html is served for it. Skipped as root, which bypasses file permissions.
+func TestStaticServer_Custom5xx(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "5xx.html"), []byte("server boom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(secret, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0000); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/secret.txt", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500", rec.Code)
+	}
+	if rec.Body.String() != "server boom" {
+		t.Errorf("body = %q, want custom 5xx.html content", rec.Body.String())
+	}
+}
+
 func TestStaticServer_HardeningHeaders(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<h1>hi</h1>"), 0644); err != nil {

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/iodesystems/homelab-horizon/internal/config"
+)
+
+func TestStaticServer_HostRouting(t *testing.T) {
+	// Two separate roots, each claimed by a different host.
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootA, "index.html"), []byte("site A"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootB, "index.html"), []byte("site B"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{
+		Services: []config.Service{
+			{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: rootA}},
+			{Name: "b", Domains: []string{"b.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: rootB}},
+			{Name: "proxied", Domains: []string{"p.example.com"}, Proxy: &config.ProxyConfig{Backend: "10.0.0.1:80"}},
+		},
+	})
+
+	tests := []struct {
+		name     string
+		host     string
+		wantCode int
+		wantBody string
+	}{
+		{"host a serves root A", "a.example.com", http.StatusOK, "site A"},
+		{"host b serves root B", "b.example.com", http.StatusOK, "site B"},
+		{"host with port strips port", "a.example.com:443", http.StatusOK, "site A"},
+		{"proxied host is not static", "p.example.com", http.StatusNotFound, ""},
+		{"unknown host 404s", "nope.example.com", http.StatusNotFound, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+			ss.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantCode {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantCode)
+			}
+			if tt.wantBody != "" && rec.Body.String() != tt.wantBody {
+				t.Errorf("body = %q, want %q", rec.Body.String(), tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestStaticServer_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// A secret outside the served root that traversal must not reach.
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretDir, "secret.txt"), []byte("top secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{
+		Services: []config.Service{
+			{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/../../../../etc/passwd", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+
+	if rec.Body.String() == "top secret" || rec.Code == http.StatusOK && rec.Body.Len() > 0 && rec.Body.String() != "ok" {
+		// http.FileServer cleans the path and confines it to root; we should
+		// never see content from outside it.
+		t.Errorf("traversal leaked content: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// Rebuild must atomically replace the map: dropping a service removes its host.
+func TestStaticServer_RebuildReplaces(t *testing.T) {
+	root := t.TempDir()
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+	if _, ok := ss.rootFor("a.example.com"); !ok {
+		t.Fatal("expected a.example.com after first rebuild")
+	}
+	ss.Rebuild(&config.Config{Services: nil})
+	if _, ok := ss.rootFor("a.example.com"); ok {
+		t.Error("expected a.example.com to be gone after rebuild with no services")
+	}
+}

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/iodesystems/homelab-horizon/internal/config"
@@ -65,11 +66,6 @@ func TestStaticServer_RejectsTraversal(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("ok"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	// A secret outside the served root that traversal must not reach.
-	secretDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(secretDir, "secret.txt"), []byte("top secret"), 0644); err != nil {
-		t.Fatal(err)
-	}
 
 	ss := newStaticServer()
 	ss.Rebuild(&config.Config{
@@ -83,10 +79,91 @@ func TestStaticServer_RejectsTraversal(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ss.ServeHTTP(rec, req)
 
-	if rec.Body.String() == "top secret" || rec.Code == http.StatusOK && rec.Body.Len() > 0 && rec.Body.String() != "ok" {
-		// http.FileServer cleans the path and confines it to root; we should
-		// never see content from outside it.
-		t.Errorf("traversal leaked content: code=%d body=%q", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("traversal not rejected: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// A symlink inside the root pointing outside it must not be followed — the
+// nastiest escape, since hz runs as root.
+func TestStaticServer_RejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	secretDir := t.TempDir()
+	secret := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "leak")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/leak", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+
+	if rec.Body.String() == "top secret" {
+		t.Errorf("symlink escape leaked secret: code=%d", rec.Code)
+	}
+}
+
+// Dotfiles (.env, .git/config, .ssh) must never be served.
+func TestStaticServer_DeniesDotfiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("SECRET=1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "config"), []byte("[core]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+
+	for _, p := range []string{"/.env", "/.git/config"} {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		req.Host = "a.example.com"
+		rec := httptest.NewRecorder()
+		ss.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s: code = %d, want 404 (body %q)", p, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// Directories are not listed: a dir without index.html 404s instead of leaking
+// a file listing.
+func TestStaticServer_NoDirectoryListing(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "private-name.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("dir without index served: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "private-name.txt") {
+		t.Errorf("directory listing leaked filenames: %q", rec.Body.String())
 	}
 }
 

--- a/ui/src/api/generated-types.ts
+++ b/ui/src/api/generated-types.ts
@@ -54,6 +54,7 @@ export interface DeployResp {
 }
 export interface ProxyResp {
   backend: string;
+  staticRoot?: string; // absolute dir served as static files (mutually exclusive with backend)
   healthCheck?: HealthCheckResp;
   internalOnly: boolean;
   deploy?: DeployResp;
@@ -378,6 +379,7 @@ export interface ServiceRequestExternalDNS {
 }
 export interface ServiceRequestProxy {
   backend: string;
+  staticRoot?: string; // absolute dir served as static files (mutually exclusive with backend)
   healthCheck?: ServiceRequestHealthCheck;
   internalOnly: boolean;
   deploy?: ServiceRequestDeploy;

--- a/ui/src/api/generated-types.ts
+++ b/ui/src/api/generated-types.ts
@@ -55,6 +55,7 @@ export interface DeployResp {
 export interface ProxyResp {
   backend: string;
   staticRoot?: string; // absolute dir served as static files (mutually exclusive with backend)
+  spa?: boolean; // static only: serve index.html for unknown non-asset paths
   healthCheck?: HealthCheckResp;
   internalOnly: boolean;
   deploy?: DeployResp;
@@ -380,6 +381,7 @@ export interface ServiceRequestExternalDNS {
 export interface ServiceRequestProxy {
   backend: string;
   staticRoot?: string; // absolute dir served as static files (mutually exclusive with backend)
+  spa?: boolean; // static only: serve index.html for unknown non-asset paths
   healthCheck?: ServiceRequestHealthCheck;
   internalOnly: boolean;
   deploy?: ServiceRequestDeploy;

--- a/ui/src/api/hooks.ts
+++ b/ui/src/api/hooks.ts
@@ -108,6 +108,7 @@ export interface ServiceMutationInput {
   proxy?: {
     backend?: string;
     staticRoot?: string;
+    spa?: boolean;
     healthCheck?: { path: string } | null;
     internalOnly: boolean;
     deploy?: { nextBackend: string; balance?: string } | null;

--- a/ui/src/api/hooks.ts
+++ b/ui/src/api/hooks.ts
@@ -106,7 +106,8 @@ export interface ServiceMutationInput {
   internalDNS?: { ip: string } | null;
   externalDNS?: { ip: string; ips?: string[]; ttl: number } | null;
   proxy?: {
-    backend: string;
+    backend?: string;
+    staticRoot?: string;
     healthCheck?: { path: string } | null;
     internalOnly: boolean;
     deploy?: { nextBackend: string; balance?: string } | null;

--- a/ui/src/routes/services.tsx
+++ b/ui/src/routes/services.tsx
@@ -134,6 +134,7 @@ interface ServiceFormState {
   proxyMode: "proxy" | "static";
   proxyBackend: string;
   staticRoot: string;
+  spa: boolean;
   healthCheckPath: string;
   internalOnly: boolean;
   deployEnabled: boolean;
@@ -156,6 +157,7 @@ const emptyForm: ServiceFormState = {
   proxyMode: "proxy",
   proxyBackend: "",
   staticRoot: "",
+  spa: false,
   healthCheckPath: "",
   internalOnly: false,
   deployEnabled: false,
@@ -182,6 +184,7 @@ function serviceToForm(svc: Service): ServiceFormState {
     proxyMode: svc.proxy?.staticRoot ? "static" : "proxy",
     proxyBackend: svc.proxy?.backend ?? "",
     staticRoot: svc.proxy?.staticRoot ?? "",
+    spa: svc.proxy?.spa ?? false,
     healthCheckPath: svc.proxy?.healthCheck?.path ?? "",
     internalOnly: svc.proxy?.internalOnly ?? false,
     deployEnabled: !!svc.proxy?.deploy,
@@ -237,6 +240,9 @@ function formToInput(form: ServiceFormState, originalName?: string): ServiceMuta
       staticRoot: form.staticRoot,
       internalOnly: form.internalOnly,
     };
+    if (form.spa) {
+      input.proxy.spa = true;
+    }
     if (form.healthCheckPath) {
       input.proxy.healthCheck = { path: form.healthCheckPath };
     }
@@ -796,14 +802,26 @@ function ServiceFormDialog({
               <MenuItem value="static">Static folder (path)</MenuItem>
             </TextField>
             {form.proxyMode === "static" ? (
-              <TextField
-                label="Static folder"
-                value={form.staticRoot}
-                onChange={(e) => update("staticRoot", e.target.value)}
-                size="small"
-                fullWidth
-                helperText="Absolute path hz serves files from, e.g. /etc/homelab-horizon/site"
-              />
+              <>
+                <TextField
+                  label="Static folder"
+                  value={form.staticRoot}
+                  onChange={(e) => update("staticRoot", e.target.value)}
+                  size="small"
+                  fullWidth
+                  helperText="Absolute path hz serves files from, e.g. /etc/homelab-horizon/site"
+                />
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Switch
+                    checked={form.spa}
+                    onChange={(e) => update("spa", e.target.checked)}
+                    size="small"
+                  />
+                  <Typography variant="body2">
+                    SPA fallback (serve index.html for unknown routes)
+                  </Typography>
+                </Box>
+              </>
             ) : (
               <TextField
                 label="Backend (host:port)"

--- a/ui/src/routes/services.tsx
+++ b/ui/src/routes/services.tsx
@@ -780,7 +780,7 @@ function ServiceFormDialog({
             onChange={(e) => update("proxyEnabled", e.target.checked)}
             size="small"
           />
-          <Typography variant="body2">Proxy</Typography>
+          <Typography variant="body2">Expose via HAProxy</Typography>
         </Box>
         {form.proxyEnabled && (
           <>

--- a/ui/src/routes/services.tsx
+++ b/ui/src/routes/services.tsx
@@ -131,7 +131,9 @@ interface ServiceFormState {
   externalIPs: string;
   externalTTL: string;
   proxyEnabled: boolean;
+  proxyMode: "proxy" | "static";
   proxyBackend: string;
+  staticRoot: string;
   healthCheckPath: string;
   internalOnly: boolean;
   deployEnabled: boolean;
@@ -151,7 +153,9 @@ const emptyForm: ServiceFormState = {
   externalIPs: "",
   externalTTL: "300",
   proxyEnabled: false,
+  proxyMode: "proxy",
   proxyBackend: "",
+  staticRoot: "",
   healthCheckPath: "",
   internalOnly: false,
   deployEnabled: false,
@@ -175,7 +179,9 @@ function serviceToForm(svc: Service): ServiceFormState {
     externalIPs: svc.externalDNS?.configuredIPs?.join(", ") ?? "",
     externalTTL: String(svc.externalDNS?.ttl ?? 300),
     proxyEnabled: !!svc.proxy,
+    proxyMode: svc.proxy?.staticRoot ? "static" : "proxy",
     proxyBackend: svc.proxy?.backend ?? "",
+    staticRoot: svc.proxy?.staticRoot ?? "",
     healthCheckPath: svc.proxy?.healthCheck?.path ?? "",
     internalOnly: svc.proxy?.internalOnly ?? false,
     deployEnabled: !!svc.proxy?.deploy,
@@ -224,7 +230,17 @@ function formToInput(form: ServiceFormState, originalName?: string): ServiceMuta
     };
   }
 
-  if (form.proxyEnabled && form.proxyBackend) {
+  // Static-folder services serve files from a local directory; HAProxy routes
+  // to hz's internal file server. Deploy/timeouts are proxy-only concepts.
+  if (form.proxyEnabled && form.proxyMode === "static" && form.staticRoot) {
+    input.proxy = {
+      staticRoot: form.staticRoot,
+      internalOnly: form.internalOnly,
+    };
+    if (form.healthCheckPath) {
+      input.proxy.healthCheck = { path: form.healthCheckPath };
+    }
+  } else if (form.proxyEnabled && form.proxyMode === "proxy" && form.proxyBackend) {
     input.proxy = {
       backend: form.proxyBackend,
       internalOnly: form.internalOnly,
@@ -769,12 +785,34 @@ function ServiceFormDialog({
         {form.proxyEnabled && (
           <>
             <TextField
-              label="Backend (host:port)"
-              value={form.proxyBackend}
-              onChange={(e) => update("proxyBackend", e.target.value)}
+              select
+              label="Backend type"
+              value={form.proxyMode}
+              onChange={(e) => update("proxyMode", e.target.value as "proxy" | "static")}
               size="small"
               fullWidth
-            />
+            >
+              <MenuItem value="proxy">Reverse proxy (host:port)</MenuItem>
+              <MenuItem value="static">Static folder (path)</MenuItem>
+            </TextField>
+            {form.proxyMode === "static" ? (
+              <TextField
+                label="Static folder"
+                value={form.staticRoot}
+                onChange={(e) => update("staticRoot", e.target.value)}
+                size="small"
+                fullWidth
+                helperText="Absolute path hz serves files from, e.g. /etc/homelab-horizon/site"
+              />
+            ) : (
+              <TextField
+                label="Backend (host:port)"
+                value={form.proxyBackend}
+                onChange={(e) => update("proxyBackend", e.target.value)}
+                size="small"
+                fullWidth
+              />
+            )}
             <TextField
               label="Health Check Path"
               value={form.healthCheckPath}
@@ -792,6 +830,8 @@ function ServiceFormDialog({
               <Typography variant="body2">Internal only</Typography>
             </Box>
 
+            {form.proxyMode === "proxy" && (
+              <>
             <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
               <Switch
                 checked={form.deployEnabled}
@@ -888,6 +928,8 @@ function ServiceFormDialog({
                 </Typography>
               </Collapse>
             </Box>
+              </>
+            )}
           </>
         )}
       </DialogContent>
@@ -1095,6 +1137,7 @@ function buildPortMapRows(services: Service[]): PortMapRow[] {
   const rows: PortMapRow[] = [];
   for (const svc of services) {
     if (!svc.proxy) continue;
+    if (svc.proxy.staticRoot) continue; // served locally by hz, no host:port to map
     const hasDeploy = !!svc.proxy.deploy;
     const noCheck = !svc.proxy.healthCheck;
     rows.push({
@@ -1467,9 +1510,9 @@ function ServiceRow({
                       indeterminate={proxyIndeterminate}
                     />
                     <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      {hasDeploy ? "Current" : "Backend"}:
+                      {service.proxy!.staticRoot ? "Static folder" : hasDeploy ? "Current" : "Backend"}:
                     </Typography>
-                    <Typography variant="body2"><code>{service.proxy!.backend}</code></Typography>
+                    <Typography variant="body2"><code>{service.proxy!.staticRoot || service.proxy!.backend}</code></Typography>
                     {service.status.proxyState && (
                       <Chip
                         label={service.status.proxyState}


### PR DESCRIPTION
Adds a **static-folder backend** type for services, so hz can serve a directory of files directly — and route to it with the same auto wildcard SSL, split-horizon DNS, and `internal_only` machinery as a proxied service.

## Why
HAProxy is a proxy/load-balancer — it can't serve a directory (no mime handling, no asset paths, single-file `http-request return` only). So the design is: **hz serves the folder, HAProxy routes to it.**

## Design
- A service sets `proxy.static_root` (absolute dir) **instead of** `proxy.backend` — mutually exclusive.
- hz runs one loopback-only file server on `static_serve_port` (default `8091`), bound to `127.0.0.1` — never publicly reachable. It selects the document root by the request **Host** header.
- `DeriveHAProxyBackends` points each static service's HAProxy backend at that internal address. **HAProxy config generation is unchanged** — it still sees a `host:port`.
- `http.FileServer` confines requests to the root (path-traversal safe).

## Changes
| Area | What |
|---|---|
| `config` | `ProxyConfig.StaticRoot`, `Config.StaticServePort` + `StaticServeAddr()` |
| validation | absolute path; mutually exclusive with `backend`; rejected with blue-green deploy |
| server | new `internal/server/static.go` host-routed loopback file server; rebuilt on every config sync; started on `Run` (skipped under dry-run) |
| API / MCP / UI | `static_root` flows through request/response types, add/edit handlers, the MCP add-service tool, and the service editor (new **Backend type** selector: reverse proxy \| static folder) |
| tests | validation, backend derivation, host routing, path-traversal, atomic rebuild |

## Dogfooding
Lets the project host its own landing page (`docs/`, merged in #26) as a static service on the public domain with auto SSL — no external web server.

```json
{ "name": "docs", "domains": ["homelab-horizon.example.com"],
  "external_dns": { "ttl": 300 },
  "proxy": { "static_root": "/etc/homelab-horizon/site" } }
```

## Verification
`go build ./...`, `go vet`, `gofmt -l`, full `go test ./...`, `golangci-lint run` (0 issues), and `tsc -b` on the UI all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)