### PR TITLE
feat(static): site uploads, self service type, and integration hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ secrets.env
 *.secret
 *.secret.*
 *.secret.properties
+
+# Generated doc-deploy integration (contains a service token)
+bin/deploy-doc

--- a/README.md
+++ b/README.md
@@ -201,6 +201,22 @@ For single-page apps, set `"spa": true` so a browser refresh on a client-side ro
   "proxy": { "static_root": "/etc/homelab-horizon/app", "spa": true } }
 ```
 
+### Deploying a static site
+
+Upload a directory with `hz-client` (the same token-authed client used for rolling deploys; grab the snippet + token from the service's **Integration** panel in the UI):
+
+```bash
+export HZ_TOKEN=<service token>  HZ_URL=https://hz.example.com
+curl -sO "$HZ_URL/admin/haproxy/hz-client" && chmod +x hz-client
+
+./hz-client site push ./public             # upload as a new release, atomic swap
+./hz-client site push ./public --validate  # dry run: extract + validate, no swap
+./hz-client site releases                  # list retained releases
+./hz-client site rollback                  # revert to the previous release
+```
+
+Deploys are **atomic**: the upload is extracted into a fresh release directory, then `static_root` (an hz-managed symlink) is repointed in a single rename — requests never see a half-written site. The last few releases are retained for `rollback`. Uploads are received by the root process, validated (no path traversal, no symlinks, size/file caps), and the files are owned by `nobody` so the unprivileged file server can read them.
+
 This is how the project hosts its own landing page (`docs/`): a static service on the public domain, served by hz, with auto SSL.
 
 ## High Availability

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ A service can serve a folder of files instead of proxying to a backend. Set `pro
   "name": "docs",
   "domains": ["docs.example.com"],
   "external_dns": { "ttl": 300 },
-  "proxy": { "static_root": "/etc/homelab-horizon/site" }
+  "proxy": { "static_root": "/var/lib/homelab-horizon/docs" }
 }
 ```
 
@@ -198,7 +198,7 @@ For single-page apps, set `"spa": true` so a browser refresh on a client-side ro
 
 ```json
 { "name": "app", "domains": ["app.example.com"],
-  "proxy": { "static_root": "/etc/homelab-horizon/app", "spa": true } }
+  "proxy": { "static_root": "/var/lib/homelab-horizon/app", "spa": true } }
 ```
 
 ### Deploying a static site

--- a/bin/hz-client
+++ b/bin/hz-client
@@ -38,6 +38,11 @@ COMMANDS
     maint-page set <file>    Set a custom 503 page from file ("-" for stdin)
     maint-page clear         Remove the custom 503 page (revert to default)
 
+  Static site (static-folder services):
+    site push <dir> [--validate]   Upload <dir> as a new release (atomic swap)
+    site rollback                  Revert to the previous release
+    site releases                  List retained releases
+
 ROLLING DEPLOY FLOW
   hz-client rolling start
   # next slot is now down — deploy new code to its backend
@@ -60,6 +65,9 @@ EXAMPLES
   hz-client maint-page set maintenance.html
   echo "<h1>Down for upgrade</h1>" | hz-client maint-page set -
   hz-client maint-page clear
+  hz-client site push ./public
+  hz-client site push ./public --validate
+  hz-client site rollback
 HELP
 }
 
@@ -95,6 +103,7 @@ HZ_URL="${HZ_URL%/}"
 AUTH="Authorization: Bearer $HZ_TOKEN"
 DEPLOY_API="$HZ_URL/api/deploy"
 BAN_API="$HZ_URL/api/ban"
+SITE_API="$HZ_URL/api/site"
 
 CMD="$1"
 shift
@@ -466,12 +475,56 @@ print(f'Maintenance page set. MD5: {md5}')
     esac
     ;;
 
+  site)
+    SUBCMD="${1:?Missing site subcommand (push|rollback|releases)}"
+    shift
+    case "$SUBCMD" in
+      push)
+        DIR="${1:?Missing directory}"
+        shift
+        VALIDATE=0
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --validate) VALIDATE=1; shift ;;
+            *) echo "Unknown site push option: $1" >&2; exit 1 ;;
+          esac
+        done
+        [ -d "$DIR" ] || { echo "Not a directory: $DIR" >&2; exit 1; }
+        Q=""
+        if [ "$VALIDATE" = 1 ]; then
+          Q="?validate=1"
+          echo "Validating $DIR (dry run, no swap)..."
+        else
+          echo "Uploading $DIR..."
+        fi
+        resp=$(tar czf - -C "$DIR" . | curl -sf -X POST -H "$AUTH" \
+          -H "Content-Type: application/gzip" --data-binary @- "$SITE_API/upload$Q") \
+          || { echo "FAILED: site upload" >&2; exit 1; }
+        echo "$resp" | python3 -m json.tool 2>/dev/null || echo "$resp"
+        ;;
+      rollback)
+        resp=$(curl -sf -X POST -H "$AUTH" "$SITE_API/rollback") || { echo "FAILED: site rollback" >&2; exit 1; }
+        echo "$resp" | python3 -m json.tool 2>/dev/null || echo "$resp"
+        ;;
+      releases)
+        resp=$(curl -sf -H "$AUTH" "$SITE_API/releases") || { echo "FAILED: site releases" >&2; exit 1; }
+        echo "$resp" | python3 -m json.tool 2>/dev/null || echo "$resp"
+        ;;
+      *)
+        echo "Unknown site subcommand: $SUBCMD"
+        echo "Subcommands: push <dir> [--validate] | rollback | releases"
+        exit 1
+        ;;
+    esac
+    ;;
+
   *)
     echo "Unknown command: $CMD"
     echo ""
     echo "Deploy:  status | current|next (up|drain|down) | swap | promote | rolling (...)"
     echo "Bans:    ban <ip> | unban <ip> | bans"
     echo "Maint:   maint-page set <file> | maint-page clear"
+    echo "Site:    site push <dir> [--validate] | site rollback | site releases"
     echo ""
     echo "Run 'hz-client --help' for full usage."
     exit 1

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,21 +8,21 @@
 <meta name="description" content="Homelab Horizon is a single-binary homelab manager for WireGuard VPN, split-horizon DNS, HAProxy reverse proxy with automatic Let's Encrypt wildcard SSL, and service health monitoring. Self-hosted, open source, runs on Ubuntu/Debian.">
 <meta name="keywords" content="homelab, homelab horizon, wireguard, vpn, split-horizon dns, reverse proxy, haproxy, lets encrypt, wildcard ssl, self-hosted, dnsmasq, route53, cloudflare, service monitoring, network management">
 <meta name="author" content="IodeSystems">
-<link rel="canonical" href="https://iodesystems.github.io/homelab-horizon/">
+<link rel="canonical" href="https://homelab-horizon.iodesystems.com/">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Homelab Horizon">
 <meta property="og:title" content="Homelab Horizon — WireGuard VPN, Split-Horizon DNS & Reverse Proxy in One Tool">
 <meta property="og:description" content="One self-hosted binary for WireGuard VPN, split-horizon DNS, HAProxy reverse proxy with automatic wildcard SSL, and service monitoring. Runs on Ubuntu/Debian.">
-<meta property="og:url" content="https://iodesystems.github.io/homelab-horizon/">
-<meta property="og:image" content="https://iodesystems.github.io/homelab-horizon/screenshots/dashboard.png">
+<meta property="og:url" content="https://homelab-horizon.iodesystems.com/">
+<meta property="og:image" content="https://homelab-horizon.iodesystems.com/screenshots/dashboard.png">
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Homelab Horizon — WireGuard VPN, Split-Horizon DNS & Reverse Proxy">
 <meta name="twitter:description" content="One self-hosted binary for WireGuard VPN, split-horizon DNS, HAProxy reverse proxy with automatic wildcard SSL, and service monitoring.">
-<meta name="twitter:image" content="https://iodesystems.github.io/homelab-horizon/screenshots/dashboard.png">
+<meta name="twitter:image" content="https://homelab-horizon.iodesystems.com/screenshots/dashboard.png">
 
 <!-- Structured data: helps Google understand this is the canonical open-source project -->
 <script type="application/ld+json">
@@ -33,7 +33,7 @@
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Ubuntu, Debian, Linux",
   "description": "A self-contained homelab management tool for WireGuard VPN, split-horizon DNS, HAProxy reverse proxy with automatic Let's Encrypt wildcard SSL, and service health monitoring. Single static binary.",
-  "url": "https://iodesystems.github.io/homelab-horizon/",
+  "url": "https://homelab-horizon.iodesystems.com/",
   "codeRepository": "https://github.com/IodeSystems/homelab-horizon",
   "license": "https://opensource.org/licenses/MIT",
   "author": { "@type": "Organization", "name": "IodeSystems", "url": "https://github.com/IodeSystems" },

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://iodesystems.github.io/homelab-horizon/sitemap.xml
+Sitemap: https://homelab-horizon.iodesystems.com/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://iodesystems.github.io/homelab-horizon/</loc>
+    <loc>https://homelab-horizon.iodesystems.com/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -57,6 +57,7 @@ type DeployResp struct {
 type ProxyResp struct {
 	Backend            string             `json:"backend"`
 	StaticRoot         string             `json:"staticRoot,omitempty"` // absolute dir served as static files (mutually exclusive with backend)
+	Self               bool               `json:"self,omitempty"`       // route to this hz instance's own admin UI
 	SPA                bool               `json:"spa,omitempty"`        // static only: serve index.html for unknown non-asset paths
 	HealthCheck        *HealthCheckResp   `json:"healthCheck,omitempty"`
 	InternalOnly       bool               `json:"internalOnly"`
@@ -434,6 +435,7 @@ type ServiceRequestExternalDNS struct {
 type ServiceRequestProxy struct {
 	Backend      string                     `json:"backend"`
 	StaticRoot   string                     `json:"staticRoot,omitempty"` // absolute dir served as static files (mutually exclusive with backend)
+	Self         bool                       `json:"self,omitempty"`       // route to this hz instance's own admin UI
 	SPA          bool                       `json:"spa,omitempty"`        // static only: serve index.html for unknown non-asset paths
 	HealthCheck  *ServiceRequestHealthCheck `json:"healthCheck,omitempty"`
 	InternalOnly bool                       `json:"internalOnly"`

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -572,6 +572,7 @@ type ServiceIntegration struct {
 	Token     string `json:"token"`
 	BaseURL   string `json:"baseURL"`
 	HasDeploy bool   `json:"hasDeploy"`
+	HasStatic bool   `json:"hasStatic"` // static-folder service: site upload available
 }
 
 // HA Fleet

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -58,6 +58,7 @@ type ProxyResp struct {
 	Backend            string             `json:"backend"`
 	StaticRoot         string             `json:"staticRoot,omitempty"` // absolute dir served as static files (mutually exclusive with backend)
 	Self               bool               `json:"self,omitempty"`       // route to this hz instance's own admin UI
+	ServedBy           string             `json:"servedBy,omitempty"`   // resolved runtime address HAProxy routes to (static/self: hz's loopback)
 	SPA                bool               `json:"spa,omitempty"`        // static only: serve index.html for unknown non-asset paths
 	HealthCheck        *HealthCheckResp   `json:"healthCheck,omitempty"`
 	InternalOnly       bool               `json:"internalOnly"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1222,7 +1222,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStartPre=+/bin/mkdir -p %s /etc/letsencrypt /etc/haproxy/certs
+ExecStartPre=+/bin/mkdir -p %s /etc/letsencrypt /etc/haproxy/certs /var/lib/homelab-horizon
 ExecStart=%s
 WorkingDirectory=%s
 Restart=on-failure
@@ -1230,9 +1230,10 @@ RestartSec=5
 User=root
 Group=root
 
-# File system isolation
+# File system isolation. /var/lib/homelab-horizon holds static-site releases
+# (the only writable, non-sensitive place for served files under the sandbox).
 ProtectSystem=strict
-ReadWritePaths=-/etc/wireguard -/etc/dnsmasq.d -/etc/haproxy -/etc/letsencrypt -/etc/systemd/system -/proc/sys/net/ipv4 -/var/lib/haproxy -%s
+ReadWritePaths=-/etc/wireguard -/etc/dnsmasq.d -/etc/haproxy -/etc/letsencrypt -/etc/systemd/system -/proc/sys/net/ipv4 -/var/lib/haproxy -/var/lib/homelab-horizon -%s
 ProtectHome=read-only
 PrivateTmp=true
 ProtectKernelTunables=true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -485,14 +485,27 @@ func (e *ExternalDNS) GetIPs() []string {
 // Static services still inherit wildcard SSL, split-horizon DNS, health
 // checks, timeouts, and internal-only restriction exactly like proxied ones.
 type ProxyConfig struct {
-	Backend         string         `json:"backend"`                    // host:port for HAProxy to forward to (mutually exclusive with StaticRoot)
+	Backend         string         `json:"backend"`                    // host:port for HAProxy to forward to (mutually exclusive with StaticRoot/Self)
 	StaticRoot      string         `json:"static_root,omitempty"`      // absolute path to a directory served as static files instead of proxying
+	Self            bool           `json:"self,omitempty"`             // route to THIS hz instance's own admin UI (resolves to the local listen addr; HA-correct)
 	SPA             bool           `json:"spa,omitempty"`              // static only: serve index.html for unknown non-asset paths (client-side routing)
 	HealthCheck     *HealthCheck   `json:"health_check,omitempty"`     // Optional health check
 	InternalOnly    bool           `json:"internal_only,omitempty"`    // Restrict to local network access only
 	Deploy          *DeployConfig  `json:"deploy,omitempty"`           // Blue-green deploy with current/next slots
 	MaintenancePage string         `json:"maintenance_page,omitempty"` // HTML body served as 503 during maintenance
 	Timeouts        *ProxyTimeouts `json:"timeouts,omitempty"`         // Optional per-backend HAProxy timeout overrides
+}
+
+// SelfBackendAddr returns the loopback address of this hz instance's own admin
+// UI, derived from ListenAddr. Used by services with proxy.self so HAProxy
+// routes to the local hz (correct per-instance, even in an HA fleet) without a
+// hardcoded host:port.
+func (c *Config) SelfBackendAddr() string {
+	_, port, err := net.SplitHostPort(c.ListenAddr)
+	if err != nil || port == "" {
+		port = "8080"
+	}
+	return "127.0.0.1:" + port
 }
 
 // StaticServeAddr returns the loopback address hz binds to serve static-folder

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,11 @@ type Config struct {
 	ListenAddr string `json:"listen_addr"`
 	AdminToken string `json:"admin_token,omitempty"`
 	KioskURL   string `json:"kiosk_url"`
+	// AdminURL, when set, is the canonical base URL hz uses for integration
+	// snippets (e.g. "https://hz.example.com"). It overrides the self-service
+	// domain and the request host. Set this when neither is what an integration
+	// client should target.
+	AdminURL string `json:"admin_url,omitempty"`
 
 	// WireGuard VPN configuration (Layer 1: VPN Clients)
 	WGInterface     string `json:"wg_interface"`

--- a/internal/config/derive.go
+++ b/internal/config/derive.go
@@ -166,9 +166,13 @@ func (c *Config) DeriveHAProxyBackends() []haproxy.Backend {
 		// static-folder service, to hz's own loopback static listener. Validation
 		// guarantees these are mutually exclusive.
 		static := svc.Proxy.StaticRoot != ""
+		self := svc.Proxy.Self
 		server := svc.Proxy.Backend
-		if static {
+		switch {
+		case static:
 			server = c.StaticServeAddr()
+		case self:
+			server = c.SelfBackendAddr()
 		}
 		if server == "" {
 			continue
@@ -186,8 +190,8 @@ func (c *Config) DeriveHAProxyBackends() []haproxy.Backend {
 		}
 
 		// Blue-green deploy: override server with current/next slots.
-		// Not applicable to static services (validation rejects the combo).
-		if !static && svc.Proxy.Deploy != nil {
+		// Not applicable to static or self services (validation rejects the combo).
+		if !static && !self && svc.Proxy.Deploy != nil {
 			b.Deploy = true
 			b.HTTPCheck = true
 			b.DeployBalance = svc.Proxy.Deploy.Balance
@@ -654,6 +658,17 @@ func (c *Config) ValidateService(svc *Service) error {
 		// runtime os.Root confinement in the static server is.
 		if isSensitiveRoot(svc.Proxy.StaticRoot) {
 			return &ValidationError{Field: "proxy.static_root", Message: "refusing to serve a system directory"}
+		}
+	}
+
+	// Self (proxy to this hz instance) is mutually exclusive with the other
+	// backend sources and with blue-green deploy.
+	if svc.Proxy != nil && svc.Proxy.Self {
+		if svc.Proxy.Backend != "" || svc.Proxy.StaticRoot != "" {
+			return &ValidationError{Field: "proxy.self", Message: "self is mutually exclusive with backend and static_root"}
+		}
+		if svc.Proxy.Deploy != nil {
+			return &ValidationError{Field: "proxy.self", Message: "self cannot be combined with blue-green deploy"}
 		}
 	}
 

--- a/internal/config/derive_test.go
+++ b/internal/config/derive_test.go
@@ -369,6 +369,28 @@ func TestDeriveHAProxyBackends_Static(t *testing.T) {
 	}
 }
 
+func TestDeriveHAProxyBackends_Self(t *testing.T) {
+	cfg := &Config{
+		ListenAddr: ":8080",
+		Services: []Service{
+			{Name: "admin", Domains: []string{"hz.example.com"}, Proxy: &ProxyConfig{Self: true, InternalOnly: true}},
+		},
+	}
+	backends := cfg.DeriveHAProxyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("expected 1 backend, got %d", len(backends))
+	}
+	if backends[0].Server != "127.0.0.1:8080" {
+		t.Errorf("self backend = %s, want 127.0.0.1:8080 (local listen addr)", backends[0].Server)
+	}
+
+	// Backend tracks a custom listen port (no hardcoded value).
+	cfg.ListenAddr = "0.0.0.0:9999"
+	if backends = cfg.DeriveHAProxyBackends(); backends[0].Server != "127.0.0.1:9999" {
+		t.Errorf("self backend = %s, want 127.0.0.1:9999", backends[0].Server)
+	}
+}
+
 func TestDeriveHAProxyBackends_MultiDomain(t *testing.T) {
 	cfg := &Config{
 		Services: []Service{
@@ -640,6 +662,21 @@ func TestValidateService(t *testing.T) {
 			name:    "domain with control character rejected",
 			svc:     Service{Name: "x", Domains: []string{"evil\n  acl.example.com"}},
 			wantErr: "domain",
+		},
+		{
+			name:    "self ok",
+			svc:     Service{Name: "admin", Domains: []string{"app.example.com"}, Proxy: &ProxyConfig{Self: true}},
+			wantErr: "",
+		},
+		{
+			name:    "self with backend rejected",
+			svc:     Service{Name: "admin", Domains: []string{"app.example.com"}, Proxy: &ProxyConfig{Self: true, Backend: "192.168.1.1:80"}},
+			wantErr: "proxy.self",
+		},
+		{
+			name:    "self with static_root rejected",
+			svc:     Service{Name: "admin", Domains: []string{"app.example.com"}, Proxy: &ProxyConfig{Self: true, StaticRoot: "/var/lib/homelab-horizon/x"}},
+			wantErr: "proxy.self",
 		},
 	}
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -71,7 +71,7 @@ func (m *Monitor) getAllChecks() []config.ServiceCheck {
 
 	// Auto-generate checks from HAProxy-proxied services
 	for _, svc := range m.config.Services {
-		if svc.Proxy == nil || svc.Proxy.Backend == "" {
+		if svc.Proxy == nil {
 			continue
 		}
 
@@ -87,15 +87,25 @@ func (m *Monitor) getAllChecks() []config.ServiceCheck {
 			continue
 		}
 
-		// Create auto-generated check
+		// Resolve what to probe:
+		//   - proxied service: its backend host:port (http if a health path is set).
+		//   - static service: hz's internal file server, which confirms the
+		//     unprivileged child process is alive. Ping only — it host-routes,
+		//     so a plain HTTP check without the right Host header would 404.
+		//   - self service: hz itself; pointless to self-monitor, so skip.
 		checkType := "ping"
-		target := svc.Proxy.Backend
-
-		// If service has a health check path, use HTTP check
-		if svc.Proxy.HealthCheck != nil && svc.Proxy.HealthCheck.Path != "" {
-			checkType = "http"
-			// Build HTTP URL from backend
-			target = "http://" + svc.Proxy.Backend + svc.Proxy.HealthCheck.Path
+		var target string
+		switch {
+		case svc.Proxy.StaticRoot != "":
+			target = m.config.StaticServeAddr()
+		case svc.Proxy.Backend != "":
+			target = svc.Proxy.Backend
+			if svc.Proxy.HealthCheck != nil && svc.Proxy.HealthCheck.Path != "" {
+				checkType = "http"
+				target = "http://" + svc.Proxy.Backend + svc.Proxy.HealthCheck.Path
+			}
+		default:
+			continue
 		}
 
 		// Check if this auto-generated check was disabled

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/iodesystems/homelab-horizon/internal/config"
+)
+
+// Auto-generated checks should cover proxied and static services, target the
+// right address, and skip self services (hz monitoring itself is pointless).
+func TestGetAllChecks_AutoGen(t *testing.T) {
+	cfg := &config.Config{
+		ListenAddr:      ":8080",
+		StaticServePort: 8091,
+		Services: []config.Service{
+			{Name: "api", Domains: []string{"api.example.com"}, Proxy: &config.ProxyConfig{Backend: "192.168.1.50:9000"}},
+			{Name: "docs", Domains: []string{"docs.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: "/var/lib/homelab-horizon/docs"}},
+			{Name: "admin", Domains: []string{"hz.example.com"}, Proxy: &config.ProxyConfig{Self: true}},
+			{Name: "plain", Domains: []string{"x.example.com"}}, // no proxy
+		},
+	}
+	m := New(cfg)
+
+	got := map[string]config.ServiceCheck{}
+	for _, c := range m.getAllChecks() {
+		got[c.Name] = c
+	}
+
+	if c, ok := got["svc:api"]; !ok || c.Type != "ping" || c.Target != "192.168.1.50:9000" {
+		t.Errorf("proxied check = %+v, want ping 192.168.1.50:9000", c)
+	}
+	// Static service is checked against hz's internal file server (child liveness).
+	if c, ok := got["svc:docs"]; !ok || c.Type != "ping" || c.Target != "127.0.0.1:8091" {
+		t.Errorf("static check = %+v, want ping 127.0.0.1:8091", c)
+	}
+	if _, ok := got["svc:admin"]; ok {
+		t.Error("self service should not get an auto-generated check")
+	}
+	if _, ok := got["svc:plain"]; ok {
+		t.Error("non-proxy service should not get an auto-generated check")
+	}
+}
+
+func TestGetAllChecks_HTTPWhenPathSet(t *testing.T) {
+	cfg := &config.Config{
+		Services: []config.Service{
+			{Name: "api", Domains: []string{"api.example.com"}, Proxy: &config.ProxyConfig{
+				Backend:     "192.168.1.50:9000",
+				HealthCheck: &config.HealthCheck{Path: "/healthz"},
+			}},
+		},
+	}
+	c := New(cfg).getAllChecks()
+	var found bool
+	for _, chk := range c {
+		if chk.Name == "svc:api" {
+			found = true
+			if chk.Type != "http" || chk.Target != "http://192.168.1.50:9000/healthz" {
+				t.Errorf("check = %+v, want http http://192.168.1.50:9000/healthz", chk)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected svc:api check")
+	}
+}

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -676,6 +676,7 @@ func (s *Server) handleAPIServiceIntegration(w http.ResponseWriter, r *http.Requ
 	baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
 	hasDeploy := svc.Proxy != nil && svc.Proxy.Deploy != nil
+	hasStatic := svc.Proxy != nil && svc.Proxy.StaticRoot != ""
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(apitypes.ServiceIntegration{
@@ -683,5 +684,6 @@ func (s *Server) handleAPIServiceIntegration(w http.ResponseWriter, r *http.Requ
 		Token:     svc.Token,
 		BaseURL:   baseURL,
 		HasDeploy: hasDeploy,
+		HasStatic: hasStatic,
 	})
 }

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -30,6 +30,23 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
+// requestScheme returns the client-facing scheme. HAProxy terminates TLS and
+// proxies plain HTTP to us, setting X-Forwarded-Proto; honor it so URLs we hand
+// back (e.g. the self-service integration snippet) reflect https. Falls back to
+// the direct connection's TLS state for non-proxied access.
+func requestScheme(r *http.Request) string {
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		if proto == "https" {
+			return "https"
+		}
+		return "http"
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
 func (s *Server) handleAPIDashboard(w http.ResponseWriter, r *http.Request) {
 	if !s.isAdmin(r) {
 		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
@@ -668,12 +685,11 @@ func (s *Server) handleAPIServiceIntegration(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	// Build base URL from request
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
+	// Build base URL from the request. HAProxy terminates TLS and forwards
+	// plain HTTP to us, so r.TLS is nil even for HTTPS clients — honor the
+	// proxy's X-Forwarded-Proto so the self-service snippet (which carries the
+	// token as a Bearer header) uses https and never leaks it over cleartext.
+	baseURL := fmt.Sprintf("%s://%s", requestScheme(r), r.Host)
 
 	hasDeploy := svc.Proxy != nil && svc.Proxy.Deploy != nil
 	hasStatic := svc.Proxy != nil && svc.Proxy.StaticRoot != ""

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -182,6 +182,14 @@ func (s *Server) handleAPIServices(w http.ResponseWriter, r *http.Request) {
 				SPA:          svc.Proxy.SPA,
 				InternalOnly: svc.Proxy.InternalOnly,
 			}
+			// Surface the resolved runtime address HAProxy routes to. For
+			// static/self the config backend is empty; it's hz's own loopback.
+			switch {
+			case svc.Proxy.StaticRoot != "":
+				pr.ServedBy = s.cfg().StaticServeAddr()
+			case svc.Proxy.Self:
+				pr.ServedBy = s.cfg().SelfBackendAddr()
+			}
 			if svc.Proxy.HealthCheck != nil {
 				pr.HealthCheck = &apitypes.HealthCheckResp{Path: svc.Proxy.HealthCheck.Path}
 			}

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -30,6 +30,19 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
+// selfServiceDomain returns the primary domain of the service marked
+// proxy.self (this hz instance's own admin UI), or "" if none. It is the
+// canonical address for integration snippets.
+func (s *Server) selfServiceDomain() string {
+	for i := range s.cfg().Services {
+		svc := &s.cfg().Services[i]
+		if svc.Proxy != nil && svc.Proxy.Self {
+			return svc.PrimaryDomain()
+		}
+	}
+	return ""
+}
+
 // requestScheme returns the client-facing scheme. HAProxy terminates TLS and
 // proxies plain HTTP to us, setting X-Forwarded-Proto; honor it so URLs we hand
 // back (e.g. the self-service integration snippet) reflect https. Falls back to
@@ -138,10 +151,11 @@ func (s *Server) handleAPIServices(w http.ResponseWriter, r *http.Request) {
 				TTL:           svc.ExternalDNS.TTL,
 			}
 		}
-		if svc.Proxy != nil && (svc.Proxy.Backend != "" || svc.Proxy.StaticRoot != "") {
+		if svc.Proxy != nil && (svc.Proxy.Backend != "" || svc.Proxy.StaticRoot != "" || svc.Proxy.Self) {
 			pr := &apitypes.ProxyResp{
 				Backend:      svc.Proxy.Backend,
 				StaticRoot:   svc.Proxy.StaticRoot,
+				Self:         svc.Proxy.Self,
 				SPA:          svc.Proxy.SPA,
 				InternalOnly: svc.Proxy.InternalOnly,
 			}
@@ -685,11 +699,20 @@ func (s *Server) handleAPIServiceIntegration(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	// Build base URL from the request. HAProxy terminates TLS and forwards
-	// plain HTTP to us, so r.TLS is nil even for HTTPS clients — honor the
-	// proxy's X-Forwarded-Proto so the self-service snippet (which carries the
-	// token as a Bearer header) uses https and never leaks it over cleartext.
-	baseURL := fmt.Sprintf("%s://%s", requestScheme(r), r.Host)
+	// Build the base URL for the integration snippet. Prefer the canonical
+	// admin domain (the service marked proxy.self) over whatever host the admin
+	// happened to browse, so snippets are consistent. HAProxy terminates TLS
+	// and forwards plain HTTP (r.TLS nil), so honor X-Forwarded-Proto; the
+	// snippet carries the token as a Bearer header and must use https.
+	scheme := requestScheme(r)
+	host := r.Host
+	if d := s.selfServiceDomain(); d != "" {
+		host = d
+		if s.cfg().SSLEnabled {
+			scheme = "https"
+		}
+	}
+	baseURL := fmt.Sprintf("%s://%s", scheme, host)
 
 	hasDeploy := svc.Proxy != nil && svc.Proxy.Deploy != nil
 	hasStatic := svc.Proxy != nil && svc.Proxy.StaticRoot != ""

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -30,6 +30,29 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
+// integrationBaseURL returns the base URL for integration snippets, in
+// precedence order:
+//  1. the configured admin_url (authoritative override);
+//  2. the self service's domain (https when SSL is enabled);
+//  3. the request host (what the admin browsed — always reachable).
+//
+// The snippet carries the service token as a Bearer header, so HTTPS is
+// preferred via requestScheme (honoring X-Forwarded-Proto behind HAProxy).
+func (s *Server) integrationBaseURL(r *http.Request) string {
+	if u := strings.TrimRight(s.cfg().AdminURL, "/"); u != "" {
+		return u
+	}
+	scheme := requestScheme(r)
+	host := r.Host
+	if d := s.selfServiceDomain(); d != "" {
+		host = d
+		if s.cfg().SSLEnabled {
+			scheme = "https"
+		}
+	}
+	return fmt.Sprintf("%s://%s", scheme, host)
+}
+
 // selfServiceDomain returns the primary domain of the service marked
 // proxy.self (this hz instance's own admin UI), or "" if none. It is the
 // canonical address for integration snippets.
@@ -699,20 +722,7 @@ func (s *Server) handleAPIServiceIntegration(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	// Build the base URL for the integration snippet. Prefer the canonical
-	// admin domain (the service marked proxy.self) over whatever host the admin
-	// happened to browse, so snippets are consistent. HAProxy terminates TLS
-	// and forwards plain HTTP (r.TLS nil), so honor X-Forwarded-Proto; the
-	// snippet carries the token as a Bearer header and must use https.
-	scheme := requestScheme(r)
-	host := r.Host
-	if d := s.selfServiceDomain(); d != "" {
-		host = d
-		if s.cfg().SSLEnabled {
-			scheme = "https"
-		}
-	}
-	baseURL := fmt.Sprintf("%s://%s", scheme, host)
+	baseURL := s.integrationBaseURL(r)
 
 	hasDeploy := svc.Proxy != nil && svc.Proxy.Deploy != nil
 	hasStatic := svc.Proxy != nil && svc.Proxy.StaticRoot != ""

--- a/internal/server/handlers_api_mutations.go
+++ b/internal/server/handlers_api_mutations.go
@@ -62,10 +62,11 @@ func serviceRequestToService(req *apitypes.ServiceRequest) config.Service {
 		}
 		svc.ExternalDNS = extDNS
 	}
-	if req.Proxy != nil && (req.Proxy.Backend != "" || req.Proxy.StaticRoot != "") {
+	if req.Proxy != nil && (req.Proxy.Backend != "" || req.Proxy.StaticRoot != "" || req.Proxy.Self) {
 		svc.Proxy = &config.ProxyConfig{
 			Backend:      req.Proxy.Backend,
 			StaticRoot:   req.Proxy.StaticRoot,
+			Self:         req.Proxy.Self,
 			SPA:          req.Proxy.SPA,
 			InternalOnly: req.Proxy.InternalOnly,
 		}
@@ -200,7 +201,7 @@ func (s *Server) handleAPIEditService(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Proxy
-			if req.Proxy != nil && (req.Proxy.Backend != "" || req.Proxy.StaticRoot != "") {
+			if req.Proxy != nil && (req.Proxy.Backend != "" || req.Proxy.StaticRoot != "" || req.Proxy.Self) {
 				// Preserve existing deploy config (token/activeSlot) and the
 				// maintenance page, which the editor doesn't round-trip.
 				var existingDeploy *config.DeployConfig
@@ -212,6 +213,7 @@ func (s *Server) handleAPIEditService(w http.ResponseWriter, r *http.Request) {
 				cfg.Services[i].Proxy = &config.ProxyConfig{
 					Backend:         req.Proxy.Backend,
 					StaticRoot:      req.Proxy.StaticRoot,
+					Self:            req.Proxy.Self,
 					SPA:             req.Proxy.SPA,
 					InternalOnly:    req.Proxy.InternalOnly,
 					MaintenancePage: existingMaintenancePage,

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -4,7 +4,56 @@ import (
 	"crypto/tls"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/iodesystems/homelab-horizon/internal/config"
 )
+
+func TestIntegrationBaseURL(t *testing.T) {
+	selfSvc := config.Service{Name: "admin", Domains: []string{"hz.example.com"}, Proxy: &config.ProxyConfig{Self: true}}
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		xfp  string
+		want string
+	}{
+		{
+			name: "admin_url overrides everything (trailing slash trimmed)",
+			cfg:  &config.Config{AdminURL: "https://hz.example.com/", SSLEnabled: true, Services: []config.Service{selfSvc}},
+			want: "https://hz.example.com",
+		},
+		{
+			name: "self service domain, https when SSL",
+			cfg:  &config.Config{SSLEnabled: true, Services: []config.Service{selfSvc}},
+			want: "https://hz.example.com",
+		},
+		{
+			name: "no admin_url, no self service -> request host + forwarded scheme",
+			cfg:  &config.Config{},
+			xfp:  "https",
+			want: "https://browsed.example.com",
+		},
+		{
+			name: "plain http fallback to request host",
+			cfg:  &config.Config{},
+			want: "http://browsed.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{}
+			s.config.Store(tt.cfg)
+			r := httptest.NewRequest("GET", "/", nil)
+			r.Host = "browsed.example.com"
+			if tt.xfp != "" {
+				r.Header.Set("X-Forwarded-Proto", tt.xfp)
+			}
+			if got := s.integrationBaseURL(r); got != tt.want {
+				t.Errorf("integrationBaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestRequestScheme(t *testing.T) {
 	tests := []struct {

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"crypto/tls"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestScheme(t *testing.T) {
+	tests := []struct {
+		name   string
+		xfp    string
+		tlsSet bool
+		want   string
+	}{
+		{"forwarded https wins (TLS terminated at proxy)", "https", false, "https"},
+		{"forwarded http", "http", false, "http"},
+		{"forwarded https beats nil TLS", "https", false, "https"},
+		{"direct TLS, no header", "", true, "https"},
+		{"plain direct", "", false, "http"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			if tt.xfp != "" {
+				r.Header.Set("X-Forwarded-Proto", tt.xfp)
+			}
+			if tt.tlsSet {
+				r.TLS = &tls.ConnectionState{}
+			}
+			if got := requestScheme(r); got != tt.want {
+				t.Errorf("requestScheme() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/handlers_site.go
+++ b/internal/server/handlers_site.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/iodesystems/homelab-horizon/internal/config"
+	"github.com/iodesystems/homelab-horizon/internal/sitedeploy"
+)
+
+const (
+	// siteReleasesKept is how many releases to retain per static site (for rollback).
+	siteReleasesKept = 5
+	// siteMaxUploadBytes caps the compressed upload body. The uncompressed
+	// total is bounded separately by sitedeploy.DefaultLimits.
+	siteMaxUploadBytes = 256 << 20
+)
+
+// handleSiteAPI handles /api/site/... for static-folder services, authenticated
+// by the per-service deploy token (Authorization: Bearer <token>).
+//
+//	POST /api/site/upload[?validate=1]   body: tar.gz of the site directory
+//	POST /api/site/rollback              revert to the previous release
+//	GET  /api/site/releases              list retained releases
+func (s *Server) handleSiteAPI(w http.ResponseWriter, r *http.Request) {
+	token := extractBearerToken(r)
+	if token == "" {
+		http.Error(w, "Authorization: Bearer <token> required", http.StatusUnauthorized)
+		return
+	}
+	idx := s.findServiceByToken(token)
+	if idx < 0 {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+	svc := &s.cfg().Services[idx]
+	if svc.Proxy == nil || svc.Proxy.StaticRoot == "" {
+		http.Error(w, "not a static-folder service", http.StatusBadRequest)
+		return
+	}
+
+	mgr := s.siteManager(svc)
+	action := strings.TrimPrefix(r.URL.Path, "/api/site/")
+	switch action {
+	case "upload":
+		s.handleSiteUpload(w, r, mgr)
+	case "rollback":
+		s.handleSiteRollback(w, r, mgr)
+	case "releases":
+		s.handleSiteReleases(w, r, mgr)
+	default:
+		http.Error(w, "unknown action", http.StatusBadRequest)
+	}
+}
+
+func (s *Server) handleSiteUpload(w http.ResponseWriter, r *http.Request, mgr *sitedeploy.Manager) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	dryRun := r.URL.Query().Get("validate") == "1" || r.URL.Query().Get("validate") == "true"
+
+	// Bound the compressed body; the uncompressed total is bounded in Deploy.
+	body := http.MaxBytesReader(w, r.Body, siteMaxUploadBytes)
+	id := time.Now().UTC().Format("20060102T150405.000000Z")
+
+	res, err := mgr.Deploy(body, id, dryRun, sitedeploy.DefaultLimits)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, res)
+}
+
+func (s *Server) handleSiteRollback(w http.ResponseWriter, r *http.Request, mgr *sitedeploy.Manager) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	rel, err := mgr.Rollback()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, map[string]string{"rolledBackTo": rel})
+}
+
+func (s *Server) handleSiteReleases(w http.ResponseWriter, r *http.Request, mgr *sitedeploy.Manager) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "GET required", http.StatusMethodNotAllowed)
+		return
+	}
+	rels, err := mgr.Releases()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, rels)
+}
+
+// siteManager builds a release manager for svc's static root. When hz runs as
+// root, extracted files are chowned to the unprivileged file-server user so the
+// child process can read them.
+func (s *Server) siteManager(svc *config.Service) *sitedeploy.Manager {
+	uid, gid := -1, -1
+	if os.Geteuid() == 0 {
+		if cred, err := unprivilegedCredential(); err == nil {
+			uid, gid = int(cred.Uid), int(cred.Gid)
+		}
+	}
+	return sitedeploy.New(svc.Proxy.StaticRoot, siteReleasesKept, uid, gid)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/server/handlers_site_test.go
+++ b/internal/server/handlers_site_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/iodesystems/homelab-horizon/internal/config"
+)
+
+func siteTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		_ = tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(content)), Typeflag: tar.TypeReg})
+		_, _ = tw.Write([]byte(content))
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	return buf.Bytes()
+}
+
+func newSiteTestServer(t *testing.T, staticRoot string) *Server {
+	t.Helper()
+	s := &Server{}
+	s.config.Store(&config.Config{
+		Services: []config.Service{{
+			Name:    "docs",
+			Token:   "tok-123",
+			Domains: []string{"docs.example.com"},
+			Proxy:   &config.ProxyConfig{StaticRoot: staticRoot},
+		}},
+	})
+	return s
+}
+
+func siteReq(method, path, token string, body []byte) *http.Request {
+	var r *http.Request
+	if body != nil {
+		r = httptest.NewRequest(method, path, bytes.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+func TestSiteAPI_UploadRollbackReleases(t *testing.T) {
+	live := filepath.Join(t.TempDir(), "site")
+	s := newSiteTestServer(t, live)
+
+	// Upload v1.
+	rec := httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodPost, "/api/site/upload", "tok-123", siteTarGz(t, map[string]string{"index.html": "v1"})))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload v1 = %d: %s", rec.Code, rec.Body.String())
+	}
+	if b, _ := os.ReadFile(filepath.Join(live, "index.html")); string(b) != "v1" {
+		t.Fatalf("served = %q, want v1", b)
+	}
+
+	// Upload v2.
+	rec = httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodPost, "/api/site/upload", "tok-123", siteTarGz(t, map[string]string{"index.html": "v2"})))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload v2 = %d: %s", rec.Code, rec.Body.String())
+	}
+	if b, _ := os.ReadFile(filepath.Join(live, "index.html")); string(b) != "v2" {
+		t.Fatalf("served = %q, want v2", b)
+	}
+
+	// Releases lists two.
+	rec = httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodGet, "/api/site/releases", "tok-123", nil))
+	var rels []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &rels); err != nil {
+		t.Fatalf("releases json: %v (%s)", err, rec.Body.String())
+	}
+	if len(rels) != 2 {
+		t.Fatalf("releases = %d, want 2", len(rels))
+	}
+
+	// Rollback to v1.
+	rec = httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodPost, "/api/site/rollback", "tok-123", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rollback = %d: %s", rec.Code, rec.Body.String())
+	}
+	if b, _ := os.ReadFile(filepath.Join(live, "index.html")); string(b) != "v1" {
+		t.Fatalf("after rollback served = %q, want v1", b)
+	}
+}
+
+func TestSiteAPI_Validate_DryRun(t *testing.T) {
+	live := filepath.Join(t.TempDir(), "site")
+	s := newSiteTestServer(t, live)
+
+	rec := httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodPost, "/api/site/upload?validate=1", "tok-123", siteTarGz(t, map[string]string{"index.html": "x"})))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("validate = %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Lstat(live); !os.IsNotExist(err) {
+		t.Error("dry-run validate created the live symlink")
+	}
+}
+
+func TestSiteAPI_Auth(t *testing.T) {
+	s := newSiteTestServer(t, filepath.Join(t.TempDir(), "site"))
+
+	// Missing token.
+	rec := httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodGet, "/api/site/releases", "", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("no token = %d, want 401", rec.Code)
+	}
+
+	// Wrong token.
+	rec = httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodGet, "/api/site/releases", "nope", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("bad token = %d, want 401", rec.Code)
+	}
+}
+
+func TestSiteAPI_RejectsNonStaticService(t *testing.T) {
+	s := &Server{}
+	s.config.Store(&config.Config{
+		Services: []config.Service{{
+			Name:    "api",
+			Token:   "tok-123",
+			Domains: []string{"api.example.com"},
+			Proxy:   &config.ProxyConfig{Backend: "127.0.0.1:9000"},
+		}},
+	})
+	rec := httptest.NewRecorder()
+	s.handleSiteAPI(rec, siteReq(http.MethodPost, "/api/site/upload", "tok-123", siteTarGz(t, map[string]string{"index.html": "x"})))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("non-static service = %d, want 400", rec.Code)
+	}
+}

--- a/internal/server/hz_client_script.go
+++ b/internal/server/hz_client_script.go
@@ -41,6 +41,11 @@ COMMANDS
     maint-page set <file>    Set a custom 503 page from file ("-" for stdin)
     maint-page clear         Remove the custom 503 page (revert to default)
 
+  Static site (static-folder services):
+    site push <dir> [--validate]   Upload <dir> as a new release (atomic swap)
+    site rollback                  Revert to the previous release
+    site releases                  List retained releases
+
 ROLLING DEPLOY FLOW
   hz-client rolling start
   # next slot is now down — deploy new code to its backend
@@ -63,6 +68,9 @@ EXAMPLES
   hz-client maint-page set maintenance.html
   echo "<h1>Down for upgrade</h1>" | hz-client maint-page set -
   hz-client maint-page clear
+  hz-client site push ./public
+  hz-client site push ./public --validate
+  hz-client site rollback
 HELP
 }
 
@@ -98,6 +106,7 @@ HZ_URL="${HZ_URL%/}"
 AUTH="Authorization: Bearer $HZ_TOKEN"
 DEPLOY_API="$HZ_URL/api/deploy"
 BAN_API="$HZ_URL/api/ban"
+SITE_API="$HZ_URL/api/site"
 
 CMD="$1"
 shift
@@ -469,12 +478,56 @@ print(f'Maintenance page set. MD5: {md5}')
     esac
     ;;
 
+  site)
+    SUBCMD="${1:?Missing site subcommand (push|rollback|releases)}"
+    shift
+    case "$SUBCMD" in
+      push)
+        DIR="${1:?Missing directory}"
+        shift
+        VALIDATE=0
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --validate) VALIDATE=1; shift ;;
+            *) echo "Unknown site push option: $1" >&2; exit 1 ;;
+          esac
+        done
+        [ -d "$DIR" ] || { echo "Not a directory: $DIR" >&2; exit 1; }
+        Q=""
+        if [ "$VALIDATE" = 1 ]; then
+          Q="?validate=1"
+          echo "Validating $DIR (dry run, no swap)..."
+        else
+          echo "Uploading $DIR..."
+        fi
+        resp=$(tar czf - -C "$DIR" . | curl -sf -X POST -H "$AUTH" \
+          -H "Content-Type: application/gzip" --data-binary @- "$SITE_API/upload$Q") \
+          || { echo "FAILED: site upload" >&2; exit 1; }
+        echo "$resp" | python3 -m json.tool 2>/dev/null || echo "$resp"
+        ;;
+      rollback)
+        resp=$(curl -sf -X POST -H "$AUTH" "$SITE_API/rollback") || { echo "FAILED: site rollback" >&2; exit 1; }
+        echo "$resp" | python3 -m json.tool 2>/dev/null || echo "$resp"
+        ;;
+      releases)
+        resp=$(curl -sf -H "$AUTH" "$SITE_API/releases") || { echo "FAILED: site releases" >&2; exit 1; }
+        echo "$resp" | python3 -m json.tool 2>/dev/null || echo "$resp"
+        ;;
+      *)
+        echo "Unknown site subcommand: $SUBCMD"
+        echo "Subcommands: push <dir> [--validate] | rollback | releases"
+        exit 1
+        ;;
+    esac
+    ;;
+
   *)
     echo "Unknown command: $CMD"
     echo ""
     echo "Deploy:  status | current|next (up|drain|down) | swap | promote | rolling (...)"
     echo "Bans:    ban <ip> | unban <ip> | bans"
     echo "Maint:   maint-page set <file> | maint-page clear"
+    echo "Site:    site push <dir> [--validate] | site rollback | site releases"
     echo ""
     echo "Run 'hz-client --help' for full usage."
     exit 1

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -868,6 +868,10 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	// the deploy token authenticates regardless of which peer serves.
 	s.handlePeerInstanceSubtree(mux, "/api/deploy/", s.handleDeployAPI)
 
+	// Static site upload API (per-service token auth, no admin/CSRF).
+	// Per-instance: site files are local to each box, like deploy slots.
+	s.handlePeerInstanceSubtree(mux, "/api/site/", s.handleSiteAPI)
+
 	// IP Ban API (deploy token auth, no CSRF). Per-instance until Phase 4
 	// LWW sync.
 	s.handlePeerInstanceSubtree(mux, "/api/ban/", s.handleBanAPI)

--- a/internal/sitedeploy/sitedeploy.go
+++ b/internal/sitedeploy/sitedeploy.go
@@ -1,0 +1,352 @@
+// Package sitedeploy manages atomic releases of a static site directory served
+// by hz. A site's served path (static_root) is an hz-managed symlink pointing
+// into a sibling releases directory; deploying extracts an uploaded tar.gz into
+// a fresh release and atomically repoints the symlink. Because the static file
+// server resolves the symlink per request, the swap is zero-downtime, and old
+// releases are retained for rollback.
+//
+// Uploads are untrusted input handled by the root process, so extraction is
+// deliberately strict: path traversal, absolute paths, and non-regular entries
+// (symlinks, devices) are rejected, and total size / file count are capped.
+package sitedeploy
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Limits bound a single upload to guard against resource exhaustion.
+type Limits struct {
+	MaxBytes int64 // total uncompressed bytes across all files
+	MaxFiles int   // total regular files
+}
+
+// DefaultLimits is a generous-but-finite cap for a static site.
+var DefaultLimits = Limits{MaxBytes: 512 << 20, MaxFiles: 20000}
+
+// Manager handles releases for one static site.
+type Manager struct {
+	live     string // the served symlink path (== static_root)
+	releases string // sibling directory holding release dirs
+	keep     int    // releases to retain (including current)
+	uid, gid int    // chown extracted files to this owner; <0 disables
+}
+
+// Result summarizes a deploy.
+type Result struct {
+	Release string `json:"release"`
+	Files   int    `json:"files"`
+	Bytes   int64  `json:"bytes"`
+	Swapped bool   `json:"swapped"`
+}
+
+// Release describes a retained release.
+type Release struct {
+	ID      string `json:"id"`
+	Current bool   `json:"current"`
+}
+
+// New returns a Manager for the given served path. keep is the number of
+// releases to retain (minimum 1). uid/gid, when >= 0, are applied to every
+// extracted file so an unprivileged file-server process can read them; pass -1
+// to skip chown (e.g. when not running as root).
+func New(staticRoot string, keep, uid, gid int) *Manager {
+	if keep < 1 {
+		keep = 1
+	}
+	clean := filepath.Clean(staticRoot)
+	return &Manager{
+		live:     clean,
+		releases: clean + "-releases",
+		keep:     keep,
+		uid:      uid,
+		gid:      gid,
+	}
+}
+
+// Deploy extracts the tar.gz from r into a new release identified by id. Unless
+// dryRun, it then atomically swaps the live symlink to the new release and
+// prunes old ones. On any failure the partial release is removed.
+func (m *Manager) Deploy(r io.Reader, id string, dryRun bool, lim Limits) (*Result, error) {
+	if err := validateID(id); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(m.releases, 0755); err != nil {
+		return nil, fmt.Errorf("create releases dir: %w", err)
+	}
+
+	dest := filepath.Join(m.releases, id)
+	if _, err := os.Lstat(dest); err == nil {
+		return nil, fmt.Errorf("release %q already exists", id)
+	}
+	tmp := dest + ".incoming"
+	_ = os.RemoveAll(tmp)
+	if err := os.MkdirAll(tmp, 0755); err != nil {
+		return nil, fmt.Errorf("create staging dir: %w", err)
+	}
+
+	files, bytes, err := extractTarGz(r, tmp, lim)
+	if err != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, err
+	}
+	if m.uid >= 0 && m.gid >= 0 {
+		if err := chownTree(tmp, m.uid, m.gid); err != nil {
+			_ = os.RemoveAll(tmp)
+			return nil, fmt.Errorf("chown release: %w", err)
+		}
+	}
+
+	if dryRun {
+		_ = os.RemoveAll(tmp)
+		return &Result{Release: id, Files: files, Bytes: bytes, Swapped: false}, nil
+	}
+
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, fmt.Errorf("finalize release: %w", err)
+	}
+	if err := m.swap(dest); err != nil {
+		_ = os.RemoveAll(dest)
+		return nil, err
+	}
+	m.prune()
+	return &Result{Release: id, Files: files, Bytes: bytes, Swapped: true}, nil
+}
+
+// swap atomically points the live symlink at relDir.
+func (m *Manager) swap(relDir string) error {
+	// Use a target relative to the symlink's directory so the tree is
+	// relocatable.
+	target, err := filepath.Rel(filepath.Dir(m.live), relDir)
+	if err != nil {
+		target = relDir
+	}
+
+	info, err := os.Lstat(m.live)
+	switch {
+	case err == nil && info.Mode()&os.ModeSymlink != 0:
+		// Existing symlink: atomic replace via temp symlink + rename.
+		tmpLink := m.live + ".swap"
+		_ = os.Remove(tmpLink)
+		if err := os.Symlink(target, tmpLink); err != nil {
+			return fmt.Errorf("stage symlink: %w", err)
+		}
+		if err := os.Rename(tmpLink, m.live); err != nil {
+			_ = os.Remove(tmpLink)
+			return fmt.Errorf("swap symlink: %w", err)
+		}
+	case err == nil && info.IsDir():
+		// A real directory occupies the served path. Adopt it only if empty;
+		// otherwise refuse rather than destroy operator data.
+		if entries, derr := os.ReadDir(m.live); derr != nil || len(entries) > 0 {
+			return fmt.Errorf("static_root %q is a non-empty directory; point it at a path hz manages for atomic deploys", m.live)
+		}
+		if err := os.Remove(m.live); err != nil {
+			return fmt.Errorf("clear empty static_root: %w", err)
+		}
+		if err := os.Symlink(target, m.live); err != nil {
+			return fmt.Errorf("create symlink: %w", err)
+		}
+	case os.IsNotExist(err):
+		if err := os.Symlink(target, m.live); err != nil {
+			return fmt.Errorf("create symlink: %w", err)
+		}
+	default:
+		if err != nil {
+			return fmt.Errorf("stat static_root: %w", err)
+		}
+		return fmt.Errorf("static_root %q is not a directory or symlink", m.live)
+	}
+	return nil
+}
+
+// Rollback repoints the live symlink to the most recent release that is not the
+// current one. Returns the release it rolled back to.
+func (m *Manager) Rollback() (string, error) {
+	rels, err := m.Releases()
+	if err != nil {
+		return "", err
+	}
+	for _, r := range rels { // Releases is newest-first
+		if !r.Current {
+			if err := m.swap(filepath.Join(m.releases, r.ID)); err != nil {
+				return "", err
+			}
+			return r.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no previous release to roll back to")
+}
+
+// Releases lists retained releases, newest first, marking the current one.
+func (m *Manager) Releases() ([]Release, error) {
+	entries, err := os.ReadDir(m.releases)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	cur := m.currentID()
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() && validateID(e.Name()) == nil {
+			ids = append(ids, e.Name())
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(ids))) // IDs are sortable timestamps
+	out := make([]Release, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, Release{ID: id, Current: id == cur})
+	}
+	return out, nil
+}
+
+// currentID returns the release the live symlink points at, or "".
+func (m *Manager) currentID() string {
+	target, err := os.Readlink(m.live)
+	if err != nil {
+		return ""
+	}
+	return filepath.Base(target)
+}
+
+// prune removes releases beyond the keep count, never removing the current one.
+func (m *Manager) prune() {
+	rels, err := m.Releases()
+	if err != nil {
+		return
+	}
+	kept := 0
+	for _, r := range rels {
+		kept++
+		if kept <= m.keep || r.Current {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(m.releases, r.ID))
+	}
+}
+
+// extractTarGz extracts a gzip-compressed tar from r into dest, enforcing
+// limits and rejecting unsafe entries. Returns the file count and total bytes.
+func extractTarGz(r io.Reader, dest string, lim Limits) (int, int64, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return 0, 0, fmt.Errorf("gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	var files int
+	var total int64
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, 0, fmt.Errorf("tar: %w", err)
+		}
+
+		name := filepath.Clean(hdr.Name)
+		if name == "." || name == "/" {
+			continue
+		}
+		if filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, ".."+string(os.PathSeparator)) {
+			return 0, 0, fmt.Errorf("unsafe path in archive: %q", hdr.Name)
+		}
+		target := filepath.Join(dest, name)
+		// Defense in depth: the joined path must stay under dest.
+		if rel, err := filepath.Rel(dest, target); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return 0, 0, fmt.Errorf("path escapes destination: %q", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return 0, 0, err
+			}
+		case tar.TypeReg:
+			files++
+			if files > lim.MaxFiles {
+				return 0, 0, fmt.Errorf("archive exceeds %d files", lim.MaxFiles)
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return 0, 0, err
+			}
+			n, err := writeFileLimited(target, tr, lim.MaxBytes-total)
+			total += n
+			if err != nil {
+				return 0, 0, err
+			}
+		default:
+			// Reject symlinks, hardlinks, devices, fifos: a static site is
+			// regular files and directories only.
+			return 0, 0, fmt.Errorf("unsupported entry %q (only files and directories allowed)", hdr.Name)
+		}
+	}
+	return files, total, nil
+}
+
+// writeFileLimited copies at most budget bytes from r into a new file at path,
+// erroring if the source is larger. Files are written 0644 so an unprivileged
+// reader can serve them.
+func writeFileLimited(path string, r io.Reader, budget int64) (int64, error) {
+	if budget <= 0 {
+		return 0, fmt.Errorf("archive exceeds size limit")
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+	// Copy budget+1 so an exactly-budget file passes but a larger one trips.
+	n, err := io.CopyN(f, r, budget+1)
+	if err != nil && err != io.EOF {
+		if n > budget {
+			return n, fmt.Errorf("archive exceeds size limit")
+		}
+		return n, err
+	}
+	if n > budget {
+		return n, fmt.Errorf("archive exceeds size limit")
+	}
+	return n, nil
+}
+
+// chownTree recursively sets ownership of root and everything under it.
+func chownTree(root string, uid, gid int) error {
+	return filepath.WalkDir(root, func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Lchown(p, uid, gid)
+	})
+}
+
+// validateID guards the release identifier used as a directory name.
+func validateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("empty release id")
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.' || r == '-' || r == '_':
+		default:
+			return fmt.Errorf("invalid release id %q", id)
+		}
+	}
+	if strings.Contains(id, "..") {
+		return fmt.Errorf("invalid release id %q", id)
+	}
+	return nil
+}

--- a/internal/sitedeploy/sitedeploy_test.go
+++ b/internal/sitedeploy/sitedeploy_test.go
@@ -1,0 +1,204 @@
+package sitedeploy
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tgz builds a gzip-compressed tar from name->content. A content of "" with a
+// trailing slash name is a directory entry.
+func tgz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0644, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// tgzRaw builds an archive from explicit headers (for malicious entries).
+func tgzRaw(t *testing.T, hdrs []*tar.Header, bodies []string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for i, h := range hdrs {
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatal(err)
+		}
+		if i < len(bodies) {
+			_, _ = tw.Write([]byte(bodies[i]))
+		}
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	return buf.Bytes()
+}
+
+func served(t *testing.T, live, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(live, rel))
+	if err != nil {
+		t.Fatalf("read %s via live symlink: %v", rel, err)
+	}
+	return string(b)
+}
+
+func TestDeploy_AtomicSwapAndRollback(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "site")
+	m := New(live, 5, -1, -1)
+
+	if _, err := m.Deploy(bytes.NewReader(tgz(t, map[string]string{"index.html": "v1"})), "20260101T000001Z", false, DefaultLimits); err != nil {
+		t.Fatal(err)
+	}
+	if got := served(t, live, "index.html"); got != "v1" {
+		t.Fatalf("after deploy 1 = %q, want v1", got)
+	}
+
+	if _, err := m.Deploy(bytes.NewReader(tgz(t, map[string]string{"index.html": "v2"})), "20260101T000002Z", false, DefaultLimits); err != nil {
+		t.Fatal(err)
+	}
+	if got := served(t, live, "index.html"); got != "v2" {
+		t.Fatalf("after deploy 2 = %q, want v2", got)
+	}
+
+	// live must be a symlink (atomic swap target), not a real dir.
+	if info, _ := os.Lstat(live); info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("live path is not a symlink")
+	}
+
+	rels, err := m.Releases()
+	if err != nil || len(rels) != 2 {
+		t.Fatalf("releases = %v (err %v), want 2", rels, err)
+	}
+	if !rels[0].Current || rels[0].ID != "20260101T000002Z" {
+		t.Errorf("newest should be current: %+v", rels[0])
+	}
+
+	rolled, err := m.Rollback()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rolled != "20260101T000001Z" {
+		t.Errorf("rolled to %q, want the v1 release", rolled)
+	}
+	if got := served(t, live, "index.html"); got != "v1" {
+		t.Fatalf("after rollback = %q, want v1", got)
+	}
+}
+
+func TestDeploy_Prune(t *testing.T) {
+	dir := t.TempDir()
+	m := New(filepath.Join(dir, "site"), 2, -1, -1)
+	ids := []string{"20260101T000001Z", "20260101T000002Z", "20260101T000003Z"}
+	for _, id := range ids {
+		if _, err := m.Deploy(bytes.NewReader(tgz(t, map[string]string{"index.html": id})), id, false, DefaultLimits); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rels, _ := m.Releases()
+	if len(rels) != 2 {
+		t.Fatalf("kept %d releases, want 2 (pruned)", len(rels))
+	}
+	// The oldest must be gone, newest retained and current.
+	if _, err := os.Stat(filepath.Join(dir, "site-releases", "20260101T000001Z")); !os.IsNotExist(err) {
+		t.Error("oldest release was not pruned")
+	}
+}
+
+func TestDeploy_DryRunDoesNotSwap(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "site")
+	m := New(live, 5, -1, -1)
+	res, err := m.Deploy(bytes.NewReader(tgz(t, map[string]string{"index.html": "x"})), "20260101T000001Z", true, DefaultLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Swapped {
+		t.Error("dry run reported a swap")
+	}
+	if _, err := os.Lstat(live); !os.IsNotExist(err) {
+		t.Error("dry run created the live symlink")
+	}
+	if rels, _ := m.Releases(); len(rels) != 0 {
+		t.Errorf("dry run left %d releases, want 0", len(rels))
+	}
+}
+
+func TestDeploy_RejectsUnsafeArchives(t *testing.T) {
+	cases := []struct {
+		name   string
+		hdrs   []*tar.Header
+		bodies []string
+	}{
+		{"traversal", []*tar.Header{{Name: "../escape.txt", Mode: 0644, Size: 1, Typeflag: tar.TypeReg}}, []string{"x"}},
+		{"absolute", []*tar.Header{{Name: "/etc/evil", Mode: 0644, Size: 1, Typeflag: tar.TypeReg}}, []string{"x"}},
+		{"nested traversal", []*tar.Header{{Name: "a/../../escape", Mode: 0644, Size: 1, Typeflag: tar.TypeReg}}, []string{"x"}},
+		{"symlink entry", []*tar.Header{{Name: "link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"}}, nil},
+		{"hardlink entry", []*tar.Header{{Name: "hl", Typeflag: tar.TypeLink, Linkname: "index.html"}}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			m := New(filepath.Join(dir, "site"), 5, -1, -1)
+			_, err := m.Deploy(bytes.NewReader(tgzRaw(t, tc.hdrs, tc.bodies)), "20260101T000001Z", false, DefaultLimits)
+			if err == nil {
+				t.Fatal("expected rejection, got nil")
+			}
+			if _, lerr := os.Lstat(filepath.Join(dir, "site")); !os.IsNotExist(lerr) {
+				t.Error("rejected upload still swapped live")
+			}
+		})
+	}
+}
+
+func TestDeploy_EnforcesLimits(t *testing.T) {
+	dir := t.TempDir()
+	m := New(filepath.Join(dir, "site"), 5, -1, -1)
+
+	// Size limit.
+	_, err := m.Deploy(bytes.NewReader(tgz(t, map[string]string{"big": "0123456789"})), "20260101T000001Z", false, Limits{MaxBytes: 5, MaxFiles: 10})
+	if err == nil {
+		t.Error("expected size-limit rejection")
+	}
+
+	// File-count limit.
+	_, err = m.Deploy(bytes.NewReader(tgz(t, map[string]string{"a": "x", "b": "x", "c": "x"})), "20260101T000002Z", false, Limits{MaxBytes: 1 << 20, MaxFiles: 2})
+	if err == nil {
+		t.Error("expected file-count rejection")
+	}
+}
+
+func TestDeploy_RefusesNonEmptyRealDir(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "site")
+	if err := os.MkdirAll(live, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(live, "existing"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(live, 5, -1, -1)
+	if _, err := m.Deploy(bytes.NewReader(tgz(t, map[string]string{"index.html": "v1"})), "20260101T000001Z", false, DefaultLimits); err == nil {
+		t.Error("expected refusal to clobber a non-empty real directory")
+	}
+}

--- a/ui/src/api/generated-types.ts
+++ b/ui/src/api/generated-types.ts
@@ -56,6 +56,7 @@ export interface ProxyResp {
   backend: string;
   staticRoot?: string; // absolute dir served as static files (mutually exclusive with backend)
   self?: boolean; // route to this hz instance's own admin UI
+  servedBy?: string; // resolved runtime address HAProxy routes to (static/self: hz's loopback)
   spa?: boolean; // static only: serve index.html for unknown non-asset paths
   healthCheck?: HealthCheckResp;
   internalOnly: boolean;

--- a/ui/src/api/generated-types.ts
+++ b/ui/src/api/generated-types.ts
@@ -55,6 +55,7 @@ export interface DeployResp {
 export interface ProxyResp {
   backend: string;
   staticRoot?: string; // absolute dir served as static files (mutually exclusive with backend)
+  self?: boolean; // route to this hz instance's own admin UI
   spa?: boolean; // static only: serve index.html for unknown non-asset paths
   healthCheck?: HealthCheckResp;
   internalOnly: boolean;
@@ -381,6 +382,7 @@ export interface ServiceRequestExternalDNS {
 export interface ServiceRequestProxy {
   backend: string;
   staticRoot?: string; // absolute dir served as static files (mutually exclusive with backend)
+  self?: boolean; // route to this hz instance's own admin UI
   spa?: boolean; // static only: serve index.html for unknown non-asset paths
   healthCheck?: ServiceRequestHealthCheck;
   internalOnly: boolean;

--- a/ui/src/api/generated-types.ts
+++ b/ui/src/api/generated-types.ts
@@ -486,6 +486,7 @@ export interface ServiceIntegration {
   token: string;
   baseURL: string;
   hasDeploy: boolean;
+  hasStatic: boolean; // static-folder service: site upload available
 }
 export interface HAFleetPeer {
   id: string;

--- a/ui/src/api/hooks.ts
+++ b/ui/src/api/hooks.ts
@@ -108,6 +108,7 @@ export interface ServiceMutationInput {
   proxy?: {
     backend?: string;
     staticRoot?: string;
+    self?: boolean;
     spa?: boolean;
     healthCheck?: { path: string } | null;
     internalOnly: boolean;

--- a/ui/src/routes/services.tsx
+++ b/ui/src/routes/services.tsx
@@ -131,7 +131,7 @@ interface ServiceFormState {
   externalIPs: string;
   externalTTL: string;
   proxyEnabled: boolean;
-  proxyMode: "proxy" | "static";
+  proxyMode: "proxy" | "static" | "self";
   proxyBackend: string;
   staticRoot: string;
   spa: boolean;
@@ -181,7 +181,7 @@ function serviceToForm(svc: Service): ServiceFormState {
     externalIPs: svc.externalDNS?.configuredIPs?.join(", ") ?? "",
     externalTTL: String(svc.externalDNS?.ttl ?? 300),
     proxyEnabled: !!svc.proxy,
-    proxyMode: svc.proxy?.staticRoot ? "static" : "proxy",
+    proxyMode: svc.proxy?.self ? "self" : svc.proxy?.staticRoot ? "static" : "proxy",
     proxyBackend: svc.proxy?.backend ?? "",
     staticRoot: svc.proxy?.staticRoot ?? "",
     spa: svc.proxy?.spa ?? false,
@@ -235,7 +235,15 @@ function formToInput(form: ServiceFormState, originalName?: string): ServiceMuta
 
   // Static-folder services serve files from a local directory; HAProxy routes
   // to hz's internal file server. Deploy/timeouts are proxy-only concepts.
-  if (form.proxyEnabled && form.proxyMode === "static" && form.staticRoot) {
+  if (form.proxyEnabled && form.proxyMode === "self") {
+    input.proxy = {
+      self: true,
+      internalOnly: form.internalOnly,
+    };
+    if (form.healthCheckPath) {
+      input.proxy.healthCheck = { path: form.healthCheckPath };
+    }
+  } else if (form.proxyEnabled && form.proxyMode === "static" && form.staticRoot) {
     input.proxy = {
       staticRoot: form.staticRoot,
       internalOnly: form.internalOnly,
@@ -800,6 +808,7 @@ function ServiceFormDialog({
             >
               <MenuItem value="proxy">Reverse proxy (host:port)</MenuItem>
               <MenuItem value="static">Static folder (path)</MenuItem>
+              <MenuItem value="self">Homelab admin UI (this instance)</MenuItem>
             </TextField>
             {form.proxyMode === "static" ? (
               <>
@@ -822,6 +831,11 @@ function ServiceFormDialog({
                   </Typography>
                 </Box>
               </>
+            ) : form.proxyMode === "self" ? (
+              <Typography variant="caption" color="text.secondary">
+                Routes this domain to this Homelab Horizon instance's own admin
+                UI. The backend tracks the local listen address automatically.
+              </Typography>
             ) : (
               <TextField
                 label="Backend (host:port)"
@@ -1166,7 +1180,7 @@ function buildPortMapRows(services: Service[]): PortMapRow[] {
   const rows: PortMapRow[] = [];
   for (const svc of services) {
     if (!svc.proxy) continue;
-    if (svc.proxy.staticRoot) continue; // served locally by hz, no host:port to map
+    if (svc.proxy.staticRoot || svc.proxy.self) continue; // served locally by hz, no host:port to map
     const hasDeploy = !!svc.proxy.deploy;
     const noCheck = !svc.proxy.healthCheck;
     rows.push({
@@ -1539,9 +1553,9 @@ function ServiceRow({
                       indeterminate={proxyIndeterminate}
                     />
                     <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      {service.proxy!.staticRoot ? "Static folder" : hasDeploy ? "Current" : "Backend"}:
+                      {service.proxy!.self ? "Admin UI" : service.proxy!.staticRoot ? "Static folder" : hasDeploy ? "Current" : "Backend"}:
                     </Typography>
-                    <Typography variant="body2"><code>{service.proxy!.staticRoot || service.proxy!.backend}</code></Typography>
+                    <Typography variant="body2"><code>{service.proxy!.self ? "this instance" : service.proxy!.staticRoot || service.proxy!.backend}</code></Typography>
                     {service.status.proxyState && (
                       <Chip
                         label={service.status.proxyState}

--- a/ui/src/routes/services.tsx
+++ b/ui/src/routes/services.tsx
@@ -1565,6 +1565,14 @@ function ServiceRow({
                       />
                     )}
                   </Box>
+                  {service.proxy!.servedBy && (
+                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", mb: 0.5 }}>
+                      <Typography variant="body2" sx={{ fontWeight: 600 }}>Served by:</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        <code>{service.proxy!.servedBy}</code> (hz internal)
+                      </Typography>
+                    </Box>
+                  )}
                   {hasDeploy && (
                     <Box sx={{ display: "flex", gap: 1, alignItems: "center", mb: 0.5 }}>
                       <StatusDot configured={true} detected={service.status.proxyNextState === "up"} />

--- a/ui/src/routes/services.tsx
+++ b/ui/src/routes/services.tsx
@@ -809,7 +809,7 @@ function ServiceFormDialog({
                   onChange={(e) => update("staticRoot", e.target.value)}
                   size="small"
                   fullWidth
-                  helperText="Absolute path hz serves files from, e.g. /etc/homelab-horizon/site"
+                  helperText="Absolute path hz serves files from, e.g. /var/lib/homelab-horizon/docs"
                 />
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <Switch

--- a/ui/src/routes/services.tsx
+++ b/ui/src/routes/services.tsx
@@ -1060,6 +1060,17 @@ function IntegrationDialog({
               `./hz-client maint-page clear                 # Restore default after upgrade`,
             ]
           : []),
+        ...(data.hasStatic
+          ? [
+              ``,
+              `# --- Static site ---`,
+              ``,
+              `./hz-client site push ./public             # Upload dir as a new release (atomic swap)`,
+              `./hz-client site push ./public --validate  # Dry run: validate without swapping`,
+              `./hz-client site releases                  # List retained releases`,
+              `./hz-client site rollback                  # Revert to the previous release`,
+            ]
+          : []),
       ].join("\n")
     : "";
 


### PR DESCRIPTION
Builds on the static-folder service backend (#27). What started as tarball uploads grew to round out static sites as a first-class, production-ready service type — plus a `self` backend type and several integration/security fixes surfaced while deploying it live.

## Static site deploys (`hz-client site …`)
Token-authed directory uploads, mirroring the blue-green deploy integration.
- `internal/sitedeploy`: extracts an uploaded `tar.gz` into a fresh release dir, then atomically repoints `static_root` (an hz-managed symlink) in one rename — zero-downtime, the file server resolves the symlink per request. Last N releases retained for **rollback**.
- Hardened extraction (untrusted tarball → root process): rejects path traversal, absolute paths, symlinks/non-regular entries; caps total size + file count; extracted files chowned to `nobody`.
- API (token auth, per-instance): `POST /api/site/upload[?validate=1]`, `POST /api/site/rollback`, `GET /api/site/releases`. `validate=1` is a dry run.
- `hz-client site push <dir> [--validate]`, `site rollback`, `site releases`.
- Integration panel shows a **Static site** section for static services.

## `self` backend type
Exposing the admin UI no longer means hardcoding `localhost:8080` / the box IP (brittle, and wrong on the other HA peer). `"proxy": { "self": true }` resolves to `127.0.0.1<listen_addr>` at derive time — tracks `listen_addr`, per-instance correct, loopback (immune to interface flap). Mutually exclusive with backend/static_root.

## Integration / security fixes
- **Token-leak fix**: the integration snippet carries the token as a Bearer header; behind HAProxy `r.TLS` is nil so it emitted `http://`. Now honors `X-Forwarded-Proto` → https.
- **`admin_url`** config knob: authoritative base URL for snippets. Precedence: `admin_url` → `self` service domain (https when SSL) → request host. Never the NAT IP.
- **Static health checks**: the monitor now auto-generates a ping check against the internal file server (`StaticServeAddr`, e.g. `127.0.0.1:8091`) — static services are a separate child process that can die; previously unmonitored. Self services skipped.

## Ops fixes (from deploying it for real)
- `ProtectSystem=strict` left static releases nowhere writable → added `/var/lib/homelab-horizon` to the unit (`ExecStartPre` mkdir + `ReadWritePaths`). The sensitive-path guard rejects `/etc`, so that's the correct home.
- Service detail card shows the resolved **Served by: `127.0.0.1:8091` (hz internal)** address.
- Docs landing page canonical/OG/sitemap URLs repointed to the real domain; `bin/deploy-doc` gitignored.

## Verification
`go build`/`vet`/`gofmt`/`go test` (sitedeploy, site API, self resolution, validation mutual-exclusivity, requestScheme/admin_url precedence, monitor auto-gen), `golangci-lint` (0 issues), `tsc`. Deployed live to a standalone host and verified end to end: atomic upload + rollback + retention through HAProxy, served by the unprivileged child, auto health check passing, served-by surfaced in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
