### PR TITLE
feat(static): Cache-Control + ETag on served files

### DIFF
--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -159,6 +159,7 @@ func (ss *staticServer) errorResponse(w http.ResponseWriter, r *http.Request, ro
 		info, statErr := f.Stat()
 		if statErr == nil && !info.IsDir() {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-store")
 			w.WriteHeader(code)
 			if r.Method != http.MethodHead {
 				_, _ = io.Copy(w, f)
@@ -206,14 +207,26 @@ func openServable(root *os.Root, name string) (*os.File, os.FileInfo, error) {
 	return f, info, nil
 }
 
-// serveContent sets an explicit Content-Type from the file extension before
-// delegating to http.ServeContent (which then handles Range and
-// If-Modified-Since). Setting it ourselves sidesteps content-sniffing and
-// system mime.types inconsistencies.
+// staticCacheControl is sent on served files. The explicit freshness both
+// enables browser/CDN caching and lets HAProxy's RAM cache store the object
+// (it won't cache responses without Cache-Control/Expires). The window is kept
+// short so an atomic deploy (which bumps the file modtime → new ETag) is
+// visible quickly; within it, ETag/If-Modified-Since revalidation returns 304.
+const staticCacheControl = "public, max-age=60"
+
+// serveContent sets an explicit Content-Type from the file extension, adds
+// cache headers, then delegates to http.ServeContent (which handles Range,
+// If-Modified-Since, and — because we set ETag — If-None-Match → 304). Setting
+// the content type ourselves sidesteps content-sniffing and system mime.types
+// inconsistencies.
 func serveContent(w http.ResponseWriter, r *http.Request, name string, info os.FileInfo, f *os.File) {
+	h := w.Header()
 	if ct := contentType(name); ct != "" {
-		w.Header().Set("Content-Type", ct)
+		h.Set("Content-Type", ct)
 	}
+	h.Set("Cache-Control", staticCacheControl)
+	// Cheap strong-ish validator: size + mtime. Changes on every deploy.
+	h.Set("ETag", fmt.Sprintf(`"%x-%x"`, info.Size(), info.ModTime().UnixNano()))
 	http.ServeContent(w, r, name, info.ModTime(), f)
 }
 
@@ -265,6 +278,7 @@ func cleanRequestPath(p string) string {
 // writeError renders the static server's standard error page for code.
 func (ss *staticServer) writeError(w http.ResponseWriter, code int) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(code)
 	text := http.StatusText(code)
 	_, _ = fmt.Fprintf(w, errorPageTmpl, code, text, code, text)

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -349,6 +349,55 @@ func TestStaticServer_Custom5xx(t *testing.T) {
 	}
 }
 
+func TestStaticServer_CacheHeaders(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "app.js"), []byte("code"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ss := newStaticServer()
+	ss.Rebuild(&config.Config{Services: []config.Service{
+		{Name: "a", Domains: []string{"a.example.com"}, Proxy: &config.ProxyConfig{StaticRoot: root}},
+	}})
+
+	// First GET: Cache-Control + ETag present.
+	req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+	req.Host = "a.example.com"
+	rec := httptest.NewRecorder()
+	ss.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != staticCacheControl {
+		t.Errorf("Cache-Control = %q, want %q", cc, staticCacheControl)
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("missing ETag")
+	}
+
+	// Conditional GET with that ETag revalidates to 304, no body.
+	req2 := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+	req2.Host = "a.example.com"
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	ss.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotModified {
+		t.Errorf("conditional GET = %d, want 304", rec2.Code)
+	}
+	if rec2.Body.Len() != 0 {
+		t.Errorf("304 should have no body, got %d bytes", rec2.Body.Len())
+	}
+
+	// Errors are not cacheable.
+	req3 := httptest.NewRequest(http.MethodGet, "/missing.js", nil)
+	req3.Host = "a.example.com"
+	rec3 := httptest.NewRecorder()
+	ss.ServeHTTP(rec3, req3)
+	if cc := rec3.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("error Cache-Control = %q, want no-store", cc)
+	}
+}
+
 func TestStaticServer_HardeningHeaders(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<h1>hi</h1>"), 0644); err != nil {


### PR DESCRIPTION
Adds `Cache-Control: public, max-age=60` + a size/mtime `ETag` to static-server 200 responses.

**Why:** static responses had no explicit freshness, so browsers/CDNs got no cache directives and HAProxy's RAM cache (`cache mycache`) skipped them entirely (it only stores responses with Cache-Control/Expires). Now:
- HAProxy caches static objects in RAM → repeat hits skip the loopback child.
- Browsers cache + revalidate cheaply (ETag/If-None-Match → 304).
- Deploy-safe: an atomic release bumps the modtime → new ETag; the 60s window keeps changes visible quickly.

Error pages (404/5xx) are `no-store`. Tests cover the headers, a 304 conditional GET, and no-store on errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)